### PR TITLE
rename SmartThingsRESTClient to SmartThingsClient

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ export * from './authenticator'
 export * from './endpoint-client'
 export * from './endpoint'
 export * from './logger'
-export * from './st-rest-client'
+export * from './st-client'
 export * from './rest-client'
 export * from './types'
 

--- a/src/st-client.ts
+++ b/src/st-client.ts
@@ -17,7 +17,7 @@ import { SchedulesEndpoint } from './endpoint//schedules'
 import { SmartThingsURLProvider, defaultSmartThingsURLProvider } from './endpoint-client'
 
 
-export class SmartThingsRESTClient extends RESTClient {
+export class SmartThingsClient extends RESTClient {
 	public readonly apps: AppsEndpoint
 	public readonly deviceprofiles: DeviceProfilesEndpoint
 	public readonly devices: DevicesEndpoint
@@ -48,7 +48,7 @@ export class SmartThingsRESTClient extends RESTClient {
 		this.schedules = new SchedulesEndpoint(this.config)
 	}
 
-	public setLocation(id: string): SmartThingsRESTClient {
+	public setLocation(id: string): SmartThingsClient {
 		this.config.locationId = id
 		return this
 	}

--- a/test/unit/apps.test.ts
+++ b/test/unit/apps.test.ts
@@ -1,7 +1,7 @@
 import axios from '../../__mocks__/axios'
 
 import { NoOpAuthenticator } from '../../src/authenticator'
-import { SmartThingsRESTClient } from '../../src/st-rest-client'
+import { SmartThingsClient } from '../../src/st-client'
 import { App, AppCreationResponse, AppRequest } from '../../src/endpoint/apps'
 import appList from './data/apps/list'
 import app1 from './data/apps/app1'
@@ -12,7 +12,7 @@ const authenticator = new NoOpAuthenticator()
 const locationId = '2fb889a9-e163-40dd-90d7-5bf2c145af16'
 const installedAppId = '0cdf204b-8a9e-4a59-b6f6-bdeb183a619f'
 const config = { locationId, installedAppId }
-const client = new SmartThingsRESTClient(authenticator, config)
+const client = new SmartThingsClient(authenticator, config)
 
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/test/unit/devices.test.ts
+++ b/test/unit/devices.test.ts
@@ -1,7 +1,7 @@
 import axios from '../../__mocks__/axios'
 
 import { NoOpAuthenticator } from '../../src/authenticator'
-import { SmartThingsRESTClient } from '../../src/st-rest-client'
+import { SmartThingsClient } from '../../src/st-client'
 import { Device } from '../../src/endpoint/devices'
 import deviceList from './data/devices/list'
 import deviceList1 from './data/devices/list1'
@@ -13,8 +13,8 @@ const authenticator = new NoOpAuthenticator()
 const locationId = '2fb889a9-e163-40dd-90d7-5bf2c145af16'
 const installedAppId = '0cdf204b-8a9e-4a59-b6f6-bdeb183a619f'
 const config = { locationId, installedAppId }
-const isaClient = new SmartThingsRESTClient(authenticator, config)
-const client = new SmartThingsRESTClient(authenticator, {})
+const isaClient = new SmartThingsClient(authenticator, config)
+const client = new SmartThingsClient(authenticator, {})
 
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
Just renamed SmartThingsRESTClient to SmartThingsClient for a cleaner API.

I was going to rename the base class but decided not to at this point. If I can think of a better name soon enough I might rename it as well, along with the config interface name (currently `RESTClientConfig`.