### PR TITLE
add capabilities to exports and fix naming conflicts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5912,9 +5912,9 @@
 			}
 		},
 		"typescript": {
-			"version": "3.8.2",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.2.tgz",
-			"integrity": "sha512-EgOVgL/4xfVrCMbhYKUQTdF37SQn4Iw73H5BgCrF1Abdun7Kwy/QZsE/ssAy0y4LxBbvua3PIbFsbRczWWnDdQ==",
+			"version": "3.8.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
+			"integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
 			"dev": true
 		},
 		"uglify-js": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
 		"prettier": "^1.19.1",
 		"ts-jest": "^24.2.0",
 		"typedoc": "^0.15.2",
-		"typescript": "^3.8.2"
+		"typescript": "^3.8.3"
 	},
 	"scripts": {
 		"format": "eslint src/**/*.ts .eslintrc.js test/**/*.ts --ignore-pattern '!.eslintrc.js' --fix",

--- a/src/endpoint/capabilities.ts
+++ b/src/endpoint/capabilities.ts
@@ -9,7 +9,7 @@ export enum Required {
 	DATA = 'data'
 }
 
-export enum CapabilityStatus {
+export enum CustomCapabilityStatus {
 	PROPOSED = 'proposed',
 	LIVE = 'live',
 	DEPRECATED = 'deprecated',
@@ -20,11 +20,6 @@ export interface CapabilitySummary {
 	id: string
 	version: number
 	status?: string
-}
-
-//might be able to remove this one, since I used getPagedItems in list functions
-export interface CapabilityList {
-	items: CapabilitySummary[]
 }
 
 export interface DataSchema {
@@ -88,8 +83,8 @@ export interface CapabilityCommand {
 }
 
 export interface CapabilityUpdate {
-	attributes?: { [name: string]: CapabilityAttribute } //name: lower camelcase
-	commands?: { [name: string]: CapabilityCommand } // name: lower camelcase
+	attributes?: { [name: string]: CapabilityAttribute } // name: lower camel case
+	commands?: { [name: string]: CapabilityCommand } // name: lower camel case
 }
 
 export interface CapabilityCreate extends CapabilityUpdate {
@@ -99,7 +94,7 @@ export interface CapabilityCreate extends CapabilityUpdate {
 export interface Capability extends CapabilityCreate {
 	id?: string
 	version?: number
-	status?: CapabilityStatus
+	status?: CustomCapabilityStatus
 }
 
 export interface Namespace {
@@ -123,13 +118,11 @@ export class CapabilitiesEndpoint extends Endpoint {
 		return list
 	}
 
-	//not public yet
 	public async listNamespaces(): Promise<Namespace[]> {
 		const list = await this.client.getPagedItems<Namespace>('/namespaces')
 		return list
 	}
 
-	//not public yet
 	public async listByNamespace(namespace: string): Promise<CapabilitySummary[]> {
 		const list = await this.client.getPagedItems<CapabilitySummary>(`/namespaces/${namespace}`)
 		return list

--- a/src/endpoint/deviceprofiles.ts
+++ b/src/endpoint/deviceprofiles.ts
@@ -1,12 +1,8 @@
 import { Endpoint } from '../endpoint'
 import EndpointClient, { EndpointClientConfig } from '../endpoint-client'
 import { Owner, Status, SuccessStatusValue } from '../types'
+import { CapabilityReference } from './devices'
 
-
-export interface CapabilityReference {
-	id: string
-	version?: number
-}
 
 export interface DeviceComponentRequest {
 	id?: string

--- a/src/endpoint/devices.ts
+++ b/src/endpoint/devices.ts
@@ -4,7 +4,7 @@ import { ConfigEntry} from './installedapps'
 import { Links, Status, SuccessStatusValue } from '../types'
 
 
-export interface Capability {
+export interface CapabilityReference {
 	id: string
 	version?: number
 }
@@ -12,7 +12,7 @@ export interface Capability {
 export interface Component {
 	id?: string // <^[-_!.~'()*0-9a-zA-Z]{1,36}$>
 	label?: string
-	capabilities: Capability[]
+	capabilities: CapabilityReference[]
 }
 
 export interface DeviceProfileReference {

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ export * from './rest-client'
 export * from './types'
 
 export * from './endpoint/apps'
+export * from './endpoint/capabilities'
 export * from './endpoint/deviceprofiles'
 export * from './endpoint/devices'
 export * from './endpoint/installedapps'


### PR DESCRIPTION
* added capabilities to exports
* fixed naming conflicts
  * fixed name of `CapabilityReference` in devices (was `Capability`)
  * used `CustomCapabilityStatus` instead of `CapabilityStatus` in capabilities so as to not conflict with `CapabilityStatus` in devices. (This object genuinely refers to *only* _custom_ capability statuses anyway.)
* bumped TypeScript version