### PR TITLE
Default installedApp.delete() to configured ISA ID

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@smartthings/core-sdk",
-	"version": "0.0.1",
+	"version": "0.0.2",
 	"description": "JavaScript/TypeScript library for using SmartThings APIs",
 	"author": "SmartThings, Inc.",
 	"homepage": "https://github.com/SmartThingsCommunity/smartthings-core-sdk",

--- a/src/endpoint/installedapps.ts
+++ b/src/endpoint/installedapps.ts
@@ -486,11 +486,12 @@ export class InstalledAppsEndpoint extends Endpoint{
 	}
 
 	/**
-	 * Deletes an installed app instance
+	 * Deletes an installed app instance. If the client is configured with an installedApp ID this value can be
+	 * omitted.
 	 * @param id UUID of the installed app
 	 */
-	public async delete(id: string): Promise<Status> {
-		await this.client.delete<Count>(id)
+	public async delete(id?: string): Promise<Status> {
+		await this.client.delete<Count>(this.installedAppId(id))
 		return SuccessStatusValue
 	}
 


### PR DESCRIPTION
Default the `client.installedApps.delete()` function to use the configured installedAppId if present. Calling this method from API Access apps is a common use-case, and is required for backward compatibility with the SmartApp SDK