### PR TITLE
fix: Catch missing/corrupted header exception in signature auth test

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@smartthings/core-sdk",
-	"version": "0.1.0",
+	"version": "0.2.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@smartthings/core-sdk",
-	"version": "0.2.0",
+	"version": "0.2.1",
 	"description": "JavaScript/TypeScript library for using SmartThings APIs",
 	"author": "SmartThings, Inc.",
 	"homepage": "https://github.com/SmartThingsCommunity/smartthings-core-sdk",


### PR DESCRIPTION
Missing or invalid auth header should simply fail auth rather than throw an exception