### PR TITLE
Make logger optional in signature verifier

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@smartthings/core-sdk",
-	"version": "0.2.3",
+	"version": "0.2.4",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/src/signature.ts
+++ b/src/signature.ts
@@ -78,7 +78,7 @@ export interface SignedHttpRequest {
 }
 
 export class SignatureVerifier {
-	constructor(private keyResolver: HttpKeyResolver, private logger: Logger) {
+	constructor(private keyResolver: HttpKeyResolver, private logger?: Logger) {
 
 	}
 


### PR DESCRIPTION
Unit test was failing. Probably induced by the upgrade of one of the packages.