### PR TITLE
fix Correctly made args field optional in sendCommands

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@smartthings/core-sdk",
-	"version": "0.2.7",
+	"version": "0.2.8",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@smartthings/core-sdk",
-	"version": "0.2.7",
+	"version": "0.2.8",
 	"description": "JavaScript/TypeScript library for using SmartThings APIs",
 	"author": "SmartThings, Inc.",
 	"homepage": "https://github.com/SmartThingsCommunity/smartthings-core-sdk",

--- a/src/endpoint/devices.ts
+++ b/src/endpoint/devices.ts
@@ -482,7 +482,7 @@ export class DevicesEndpoint extends Endpoint {
 	 * @param args list of arguments. Required when a capability ID has been specified and the command has arguments
 	 */
 	public sendCommands(items: ConfigEntry[], capabilityIdOrCmdList: string | CommandRequest[],
-			command: string, args: (object | string | number)[]): Promise<Status[]> {
+			command: string, args?: (object | string | number)[]): Promise<Status[]> {
 		const results = []
 		if (items) {
 			for (const it of items) {

--- a/test/unit/devices.test.ts
+++ b/test/unit/devices.test.ts
@@ -246,7 +246,7 @@ describe('Devices',  () => {
 				],
 			},
 		}
-		const response: Status[] = await client.devices.sendCommands([configEntry], 'switch', 'on', [])
+		const response: Status[] = await client.devices.sendCommands([configEntry], 'switch', 'on')
 		expect(axios.request).toHaveBeenCalledWith(expectedRequest(turnOn1.request))
 		expect(response.length).toEqual(1)
 		expect(response[0]).toBe(SuccessStatusValue)


### PR DESCRIPTION
Implementation already handled lack of args, but declaration of sendCommands didn't makes args optional.