### PR TITLE
fix Corrected DeviceConfig type defs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@smartthings/core-sdk",
-	"version": "0.2.9",
+	"version": "0.2.10",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@smartthings/core-sdk",
-	"version": "0.2.9",
+	"version": "0.2.10",
 	"description": "JavaScript/TypeScript library for using SmartThings APIs",
 	"author": "SmartThings, Inc.",
 	"homepage": "https://github.com/SmartThingsCommunity/smartthings-core-sdk",

--- a/src/endpoint/installedapps.ts
+++ b/src/endpoint/installedapps.ts
@@ -7,7 +7,7 @@ export interface StringConfig {
 	/**
 	 * A config value
 	 */
-	value?: string
+	value: string
 }
 
 export interface DeviceConfig {
@@ -18,34 +18,34 @@ export interface DeviceConfig {
 	/**
 	 * The component ID on the device.
 	 */
-	componentId?: string
-	permissions?: string[]
+	componentId: string
+	permissions: string[]
 }
 
 export interface PermissionConfig {
-	permissions?: string[]
+	permissions: string[]
 }
 
 export interface ModeConfig {
 	/**
 	 * The ID of the mode.
 	 */
-	modeId?: string
+	modeId: string
 }
 
 export interface SceneConfig {
 	/**
 	 * The ID of the scene.
 	 */
-	sceneId?: string
-	permissions?: string[]
+	sceneId: string
+	permissions: string[]
 }
 
 export interface MessageConfig {
 	/**
 	 * The key value of the message group.
 	 */
-	messageGroupKey?: string
+	messageGroupKey: string
 }
 
 export enum ConfigValueType {


### PR DESCRIPTION
Changed the properties of the various SmartApp config classes to not be optional. These values are always set in device config API responses. Their being optional creates a need for unnecessary checks in typescript clients.