### PR TITLE
fix: correct spelling of SchemaCreateResponse

### DIFF
--- a/src/endpoint/schema.ts
+++ b/src/endpoint/schema.ts
@@ -179,7 +179,7 @@ interface InstalledSchemaAppList {
 	installedSmartApps: InstalledSchemaApp[]
 }
 
-export interface SchemaCreateReponse {
+export interface SchemaCreateResponse {
 	endpointAppId?: string
 	stClientId: string
 	stClientSecret: string
@@ -242,8 +242,8 @@ export class SchemaEndpoint extends Endpoint {
 	 * Create an ST Schema connector
 	 * @param data definition of the connector
 	 */
-	public create(data: SchemaAppRequest): Promise<SchemaCreateReponse> {
-		return this.client.post<SchemaCreateReponse>('apps', data)
+	public create(data: SchemaAppRequest): Promise<SchemaCreateResponse> {
+		return this.client.post<SchemaCreateResponse>('apps', data)
 	}
 
 	/**

--- a/test/unit/data/presentation/presentation.ts
+++ b/test/unit/data/presentation/presentation.ts
@@ -27,7 +27,7 @@ const data = {
 				'visibleCondition': {
 					'component': 'component',
 					'version': 1,
-					'attribute': 'attributeName',
+					'value': 'valueName',
 					'operator': CapabilityPresentationOperator.GREATER_THAN_OR_EQUALS,
 					'operand': 'keyName',
 				} as CapabilityVisibleCondition,
@@ -44,7 +44,7 @@ const data = {
 				'visibleCondition': {
 					'component': 'component',
 					'version': 1,
-					'attribute': 'attributeName',
+					'value': 'valueName',
 					'operator': CapabilityPresentationOperator.GREATER_THAN_OR_EQUALS,
 					'operand': 'keyName',
 				} as CapabilityVisibleCondition,
@@ -62,7 +62,7 @@ const data = {
 			'visibleCondition': {
 				'component': 'component',
 				'version': 1,
-				'attribute': 'attributeName',
+				'value': 'valueName',
 				'operator': CapabilityPresentationOperator.GREATER_THAN_OR_EQUALS,
 				'operand': 'keyName',
 			} as CapabilityVisibleCondition,
@@ -80,7 +80,7 @@ const data = {
 				'visibleCondition': {
 					'component': 'component',
 					'version': 1,
-					'attribute': 'attributeName',
+					'value': 'valueName',
 					'operator': CapabilityPresentationOperator.GREATER_THAN_OR_EQUALS,
 					'operand': 'keyName',
 				} as CapabilityVisibleCondition,
@@ -97,7 +97,7 @@ const data = {
 				'visibleCondition': {
 					'component': 'component',
 					'version': 1,
-					'attribute': 'attributeName',
+					'value': 'valueName',
 					'operator': CapabilityPresentationOperator.GREATER_THAN_OR_EQUALS,
 					'operand': 'keyName',
 				} as CapabilityVisibleCondition,


### PR DESCRIPTION
- fix misspelling of `SchemaCreateResponse`
- fix failing tests due to type changes in previous PR