### PR TITLE
fix Corrected get device presentation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@smartthings/core-sdk",
-	"version": "0.2.12",
+	"version": "0.2.13",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@smartthings/core-sdk",
-	"version": "0.2.12",
+	"version": "0.2.13",
 	"description": "JavaScript/TypeScript library for using SmartThings APIs",
 	"author": "SmartThings, Inc.",
 	"homepage": "https://github.com/SmartThingsCommunity/smartthings-core-sdk",

--- a/src/endpoint/presentation.ts
+++ b/src/endpoint/presentation.ts
@@ -191,7 +191,13 @@ export class PresentationEndpoint extends Endpoint {
 		return this.client.post<PresentationDeviceConfig>('deviceconfig', deviceConfig)
 	}
 
-	public getPresentation(vid: string): Promise<PresentationDevicePresentation> {
-		return this.client.get<PresentationDevicePresentation>('', { vid })
+	/**
+	 * Get a device presentation. If mnmn is omitted the default SmartThingsCommunity mnmn is used.
+	 * @param deviceId UUID of the device
+	 * @param mnmn The manufacturer name, e.g. SmartThingsCommunity
+	 * @param vid The id returned from the device config create operation
+	 */
+	public getPresentation(deviceId: string, mnmn: string, vid: string): Promise<PresentationDevicePresentation> {
+		return this.client.get<PresentationDevicePresentation>('', { vid, mnmn, deviceId })
 	}
 }


### PR DESCRIPTION
Corrected problem where presentations.getPresentation() did not have the correct arguments, namely `deviceId`, `mnmn`, and `vid`.