### PR TITLE
fix Separate device presentation methods

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@smartthings/core-sdk",
-	"version": "0.2.13",
+	"version": "0.2.14",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@smartthings/core-sdk",
-	"version": "0.2.13",
+	"version": "0.2.14",
 	"description": "JavaScript/TypeScript library for using SmartThings APIs",
 	"author": "SmartThings, Inc.",
 	"homepage": "https://github.com/SmartThingsCommunity/smartthings-core-sdk",

--- a/src/endpoint/devices.ts
+++ b/src/endpoint/devices.ts
@@ -2,6 +2,7 @@ import { Endpoint } from '../endpoint'
 import EndpointClient, { EndpointClientConfig, HttpClientParams } from '../endpoint-client'
 import { ConfigEntry} from './installedapps'
 import { Links, Status, SuccessStatusValue } from '../types'
+import {PresentationDevicePresentation} from './presentation'
 
 
 export interface CapabilityReference {
@@ -510,6 +511,14 @@ export class DevicesEndpoint extends Endpoint {
 	 */
 	public sendEvents(id: string, deviceEvents: DeviceEventList): void {
 		this.client.post(`${id}/events`, deviceEvents)
+	}
+
+	/**
+	 * Get a device presentation. If mnmn is omitted the default SmartThingsCommunity mnmn is used.
+	 * @param deviceId UUID of the device
+	 */
+	public getPresentation(deviceId: string): Promise<PresentationDevicePresentation> {
+		return this.client.get<PresentationDevicePresentation>('/presentation', { deviceId })
 	}
 
 	/**

--- a/src/endpoint/presentation.ts
+++ b/src/endpoint/presentation.ts
@@ -193,11 +193,14 @@ export class PresentationEndpoint extends Endpoint {
 
 	/**
 	 * Get a device presentation. If mnmn is omitted the default SmartThingsCommunity mnmn is used.
-	 * @param deviceId UUID of the device
-	 * @param mnmn The manufacturer name, e.g. SmartThingsCommunity
 	 * @param vid The id returned from the device config create operation
+	 * @param mnmn The manufacturer name, e.g. SmartThingsCommunity
 	 */
-	public getPresentation(deviceId: string, mnmn: string, vid: string): Promise<PresentationDevicePresentation> {
-		return this.client.get<PresentationDevicePresentation>('', { vid, mnmn, deviceId })
+	public getPresentation(vid: string, mnmn?: string): Promise<PresentationDevicePresentation> {
+		if (mnmn) {
+			return this.client.get<PresentationDevicePresentation>('', { vid, mnmn })
+		} else {
+			return this.client.get<PresentationDevicePresentation>('', { vid })
+		}
 	}
 }


### PR DESCRIPTION
Added `devices.getPresentation(deviceId)` method to get the presentation of a device and `presentation.getPresentation(vid, [mnmn])` to get presentation for a vid and mnmn.