### PR TITLE
feat: allow CapabilityCreate to accept params

### DIFF
--- a/src/endpoint/capabilities.ts
+++ b/src/endpoint/capabilities.ts
@@ -1,5 +1,5 @@
 import { Endpoint } from '../endpoint'
-import EndpointClient, { EndpointClientConfig } from '../endpoint-client'
+import EndpointClient, { EndpointClientConfig, HttpClientParams } from '../endpoint-client'
 import { Status, SuccessStatusValue } from '../types'
 
 
@@ -677,8 +677,8 @@ export class CapabilitiesEndpoint extends Endpoint {
 		return this.client.get<Capability>(`${capabilityId}/${capabilityVersion}`)
 	}
 
-	public create(capability: CapabilityCreate): Promise<Capability> {
-		return this.client.post(undefined, capability)
+	public create(capability: CapabilityCreate, params?: HttpClientParams): Promise<Capability> {
+		return this.client.post(undefined, capability, params)
 	}
 
 	public update(capabilityId: string, capabilityVersion: number, capability: CapabilityUpdate): Promise<Capability> {

--- a/test/unit/capabilities.test.ts
+++ b/test/unit/capabilities.test.ts
@@ -1,6 +1,6 @@
 import axios from '../../__mocks__/axios'
 
-import { NoOpAuthenticator, SmartThingsClient, Capability, CapabilitySummary, CapabilityCreate, CapabilityNamespace } from '../../src'
+import { NoOpAuthenticator, SmartThingsClient, Capability, CapabilitySummary, CapabilityCreate, CapabilityNamespace, HttpClientParams } from '../../src'
 import capability1 from './data/capabilities/capability1'
 import capabilitiesList from './data/capabilities/list'
 import capabilitiesList1 from './data/capabilities/list1'
@@ -114,6 +114,18 @@ describe('Capabilities',  () => {
 
 		expect(axios.request).toHaveBeenCalledTimes(1)
 		expect(axios.request).toHaveBeenCalledWith(expectedRequest('capabilities', undefined, reqData, 'post'))
+		expect(response).toBe(resData)
+	})
+
+	it('create with params', async () => {
+		const reqData: CapabilityCreate = create1
+		const resData: Capability = capability1
+		axios.request.mockImplementationOnce(() => Promise.resolve({status: 200, data: resData}))
+		const params: HttpClientParams = {'namespace': 'namespace'}
+		const response: Capability = await client.capabilities.create(reqData, params)
+
+		expect(axios.request).toHaveBeenCalledTimes(1)
+		expect(axios.request).toHaveBeenCalledWith(expectedRequest('capabilities', params, reqData, 'post'))
 		expect(response).toBe(resData)
 	})
 })


### PR DESCRIPTION
* add ability to pass arbitrary HTTP params to the CapabilitiesEndpoint create method