### PR TITLE
fix Added missing capability schema properties

### DIFF
--- a/src/endpoint/capabilities.ts
+++ b/src/endpoint/capabilities.ts
@@ -43,6 +43,9 @@ export interface CapabilityJSONSchema {
 	maxLength?: number
 	enum?: string[]
 	propertyName?: unknown
+	properties?: { [name: string]: CapabilityJSONSchema }
+	items?: CapabilityJSONSchema | [CapabilityJSONSchema]
+	title?: string
 }
 
 export interface CapabilityAttributeProperties {


### PR DESCRIPTION
Added additional properties found in capability schemas while making CLI enhancements:

`properties?: { [name: string]: CapabilityJSONSchema }`
[nested properties](https://github.com/SmartThingsCommunity/SmartThingsCapabilities/blob/master/capabilities/web-rtc.src/webrtc.yml#L34-L44)

`items?: CapabilityJSONSchema | [CapabilityJSONSchema]`
[items as a schema object](https://github.com/SmartThingsCommunity/SmartThingsCapabilities/blob/master/capabilities/web-rtc.src/webrtc.yml#L12-L13)
[items as an array of schema objects](https://github.com/SmartThingsCommunity/SmartThingsCapabilities/blob/master/capabilities/thermostat.src/thermostat.yml#L17-L19)

`title?: string`
[title of type](https://github.com/SmartThingsCommunity/SmartThingsCapabilities/blob/master/capabilities/thermostat.src/thermostat.yml#L51) ([definition](https://github.com/SmartThingsCommunity/SmartThingsCapabilities/blob/master/datatypes/JsonArray.yml))
