### PR TITLE
fix: export EndpointClient class normally so it can be used directly outside SDK

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -68,7 +68,9 @@ module.exports = {
 			},
 		],
 		'@typescript-eslint/consistent-type-definitions': ['error', 'interface'],
-		'@typescript-eslint/explicit-function-return-type': 'error',
+		'@typescript-eslint/explicit-function-return-type': ['error', {
+			allowExpressions: true,
+		}],
 		'@typescript-eslint/no-explicit-any': 'error',
 		'@typescript-eslint/no-non-null-assertion': 'error',
 		'no-use-before-define': 'off',

--- a/src/endpoint-client.ts
+++ b/src/endpoint-client.ts
@@ -54,7 +54,7 @@ export interface ItemsList {
 	}
 }
 
-export default class EndpointClient {
+export class EndpointClient {
 	private logger: Logger
 
 	constructor(public readonly basePath: string, public readonly config: EndpointClientConfig) {

--- a/src/endpoint.ts
+++ b/src/endpoint.ts
@@ -1,4 +1,4 @@
-import EndpointClient from './endpoint-client'
+import { EndpointClient } from './endpoint-client'
 
 
 export class Endpoint {

--- a/src/endpoint/apps.ts
+++ b/src/endpoint/apps.ts
@@ -1,4 +1,4 @@
-import EndpointClient, {EndpointClientConfig, HttpClientParams} from '../endpoint-client'
+import { EndpointClient, EndpointClientConfig, HttpClientParams } from '../endpoint-client'
 import { Endpoint } from '../endpoint'
 import { Count, IconImage, Owner, PrincipalType, Status, SuccessStatusValue } from '../types'
 

--- a/src/endpoint/capabilities.ts
+++ b/src/endpoint/capabilities.ts
@@ -1,5 +1,5 @@
 import { Endpoint } from '../endpoint'
-import EndpointClient, { EndpointClientConfig, HttpClientParams } from '../endpoint-client'
+import { EndpointClient, EndpointClientConfig, HttpClientParams } from '../endpoint-client'
 import { Status, SuccessStatusValue } from '../types'
 
 

--- a/src/endpoint/deviceprofiles.ts
+++ b/src/endpoint/deviceprofiles.ts
@@ -1,5 +1,5 @@
 import { Endpoint } from '../endpoint'
-import EndpointClient, { EndpointClientConfig } from '../endpoint-client'
+import { EndpointClient, EndpointClientConfig } from '../endpoint-client'
 import { Owner, Status, SuccessStatusValue } from '../types'
 import { CapabilityReference } from './devices'
 

--- a/src/endpoint/devices.ts
+++ b/src/endpoint/devices.ts
@@ -1,5 +1,5 @@
 import { Endpoint } from '../endpoint'
-import EndpointClient, { EndpointClientConfig, HttpClientParams } from '../endpoint-client'
+import { EndpointClient, EndpointClientConfig, HttpClientParams } from '../endpoint-client'
 import { ConfigEntry} from './installedapps'
 import { Links, Status, SuccessStatusValue } from '../types'
 import {PresentationDevicePresentation} from './presentation'

--- a/src/endpoint/installedapps.ts
+++ b/src/endpoint/installedapps.ts
@@ -1,5 +1,5 @@
 import { Endpoint } from '../endpoint'
-import EndpointClient, { EndpointClientConfig, HttpClientParams } from '../endpoint-client'
+import { EndpointClient, EndpointClientConfig, HttpClientParams } from '../endpoint-client'
 import { Count, Owner, PrincipalType, Status, SuccessStatusValue } from '../types'
 
 

--- a/src/endpoint/locations.ts
+++ b/src/endpoint/locations.ts
@@ -1,5 +1,5 @@
 import { Endpoint } from '../endpoint'
-import EndpointClient, { EndpointClientConfig } from '../endpoint-client'
+import { EndpointClient, EndpointClientConfig } from '../endpoint-client'
 import { Status, SuccessStatusValue } from '../types'
 
 

--- a/src/endpoint/modes.ts
+++ b/src/endpoint/modes.ts
@@ -1,5 +1,5 @@
 import { Endpoint } from '../endpoint'
-import EndpointClient, { EndpointClientConfig } from '../endpoint-client'
+import { EndpointClient, EndpointClientConfig } from '../endpoint-client'
 import { Status, SuccessStatusValue } from '../types'
 
 

--- a/src/endpoint/notifications.ts
+++ b/src/endpoint/notifications.ts
@@ -1,5 +1,5 @@
 import { Endpoint } from '../endpoint'
-import EndpointClient, {EndpointClientConfig} from '../endpoint-client'
+import { EndpointClient, EndpointClientConfig } from '../endpoint-client'
 
 
 export enum NotificationRequestType {

--- a/src/endpoint/presentation.ts
+++ b/src/endpoint/presentation.ts
@@ -1,5 +1,5 @@
 import { Endpoint } from '../endpoint'
-import EndpointClient, { EndpointClientConfig, HttpClientParams } from '../endpoint-client'
+import { EndpointClient, EndpointClientConfig, HttpClientParams } from '../endpoint-client'
 import {
 	CapabilityVisibleCondition,
 	CapabilityLabeledState,

--- a/src/endpoint/rooms.ts
+++ b/src/endpoint/rooms.ts
@@ -1,5 +1,5 @@
 import { Endpoint } from '../endpoint'
-import EndpointClient, { EndpointClientConfig } from '../endpoint-client'
+import { EndpointClient, EndpointClientConfig } from '../endpoint-client'
 import { Status, SuccessStatusValue } from '../types'
 import { Device } from './devices'
 

--- a/src/endpoint/rules.ts
+++ b/src/endpoint/rules.ts
@@ -1,5 +1,5 @@
 import { Endpoint } from '../endpoint'
-import EndpointClient, { EndpointClientConfig } from '../endpoint-client'
+import { EndpointClient, EndpointClientConfig } from '../endpoint-client'
 import { SuccessStatusValue, Status } from '../types'
 
 

--- a/src/endpoint/scenes.ts
+++ b/src/endpoint/scenes.ts
@@ -1,5 +1,5 @@
 import { Endpoint } from '../endpoint'
-import EndpointClient, { EndpointClientConfig, HttpClientParams } from '../endpoint-client'
+import { EndpointClient, EndpointClientConfig, HttpClientParams } from '../endpoint-client'
 import { Status } from '../types'
 
 

--- a/src/endpoint/schedules.ts
+++ b/src/endpoint/schedules.ts
@@ -1,6 +1,6 @@
 import {isString, isDate} from 'underscore'
 import { Endpoint } from '../endpoint'
-import EndpointClient, { EndpointClientConfig } from '../endpoint-client'
+import { EndpointClient, EndpointClientConfig } from '../endpoint-client'
 import { Status, SuccessStatusValue } from '../types'
 import { ConfigEntry } from './installedapps'
 import { Location } from './locations'

--- a/src/endpoint/schema.ts
+++ b/src/endpoint/schema.ts
@@ -1,5 +1,5 @@
 import { Endpoint } from '../endpoint'
-import EndpointClient, { EndpointClientConfig } from '../endpoint-client'
+import { EndpointClient, EndpointClientConfig } from '../endpoint-client'
 import { SuccessStatusValue, Status } from '../types'
 
 

--- a/src/endpoint/services.ts
+++ b/src/endpoint/services.ts
@@ -1,5 +1,5 @@
 import { Endpoint } from '../endpoint'
-import EndpointClient, { EndpointClientConfig } from '../endpoint-client'
+import { EndpointClient, EndpointClientConfig } from '../endpoint-client'
 import { SuccessStatusValue, Status } from '../types'
 
 

--- a/src/endpoint/subscriptions.ts
+++ b/src/endpoint/subscriptions.ts
@@ -1,5 +1,5 @@
 import { Endpoint } from '../endpoint'
-import EndpointClient, { EndpointClientConfig } from '../endpoint-client'
+import { EndpointClient, EndpointClientConfig } from '../endpoint-client'
 import { Count } from '../types'
 import { ConfigEntry } from './installedapps'
 

--- a/test/unit/endpoint-client.test.ts
+++ b/test/unit/endpoint-client.test.ts
@@ -8,7 +8,7 @@ import {
 	RefreshTokenStore,
 	SequentialRefreshTokenAuthenticator,
 } from '../../src'
-import EndpointClient, { defaultSmartThingsURLProvider } from '../../src/endpoint-client'
+import { defaultSmartThingsURLProvider, EndpointClient } from '../../src/endpoint-client'
 
 
 class TokenStore implements RefreshTokenStore {


### PR DESCRIPTION
Removed `default` from export for `EndpointClient` class and fixed imports so it gets exported for external use.