### PR TITLE
chore: configure semantic-release to use PI bot

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,3 +6,7 @@ indent_size = 4
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
+
+[*.{yml,yaml}]
+indent_style = space
+indent_size = 2

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -20,6 +20,10 @@ jobs:
       - run: npm ci
       - name: Release
         env:
-          GITHUB_TOKEN: ${{ secrets.PI_GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.PI_GITHUB_TOKEN }}
+          GIT_AUTHOR_NAME: smartthingspi
+          GIT_AUTHOR_EMAIL: pi-team@smartthings.com
+          GIT_COMMITTER_NAME: smartthingspi
+          GIT_COMMITTER_EMAIL: pi-team@smartthings.com
         run: npx semantic-release


### PR DESCRIPTION
* update our workflow to set env variables [detailed here](https://github.com/semantic-release/git#git-authentication)

This will allow us to have branch protections in place while also automating these chore commits from releases.