### PR TITLE
chore: add ability to manually run release

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - master
+  workflow_dispatch:
+    branches:
+      - master
 
 jobs:
   release:


### PR DESCRIPTION
* include [workflow_dispatch](https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/) events on master branch