### PR TITLE
fix: can be set `stateChangeOnly` false

### DIFF
--- a/src/endpoint/subscriptions.ts
+++ b/src/endpoint/subscriptions.ts
@@ -329,7 +329,7 @@ export class SubscriptionsEndpoint extends Endpoint {
 						componentId: item.deviceConfig.componentId,
 						capability: capability,
 						attribute: attributeName,
-						stateChangeOnly: options.stateChangeOnly ? options.stateChangeOnly : true,
+						stateChangeOnly: options.stateChangeOnly !== undefined ? options.stateChangeOnly : true,
 						subscriptionName: `${subscriptionName}_${index}`,
 						value: attributeValue,
 					}
@@ -370,7 +370,7 @@ export class SubscriptionsEndpoint extends Endpoint {
 			locationId: this.locationId(),
 			capability,
 			attribute: attributeName,
-			stateChangeOnly: options.stateChangeOnly ? options.stateChangeOnly : true,
+			stateChangeOnly: options.stateChangeOnly !== undefined ? options.stateChangeOnly : true,
 			subscriptionName,
 			value: attributeValue,
 		}


### PR DESCRIPTION
 - If `options.stateChangeOnly` is `false`,  `true` will be set to `stateChangeOnly` field by ternary operator.
 - Changed to check `options.stateChangeOnly` is `undefined` or not.