### PR TITLE
feat: Add patch property to device configs

### DIFF
--- a/src/endpoint/presentation.ts
+++ b/src/endpoint/presentation.ts
@@ -12,6 +12,26 @@ import {
 	CapabilityAutomationAction} from './capabilities'
 
 
+export enum PatchItemOpEnum {
+	ADD = 'add',
+	REPLACE = 'replace',
+	REMOVE = 'remove'
+}
+export interface PatchItem {
+	/**
+	 * Operation objects MUST have exactly one \"op\" member, whose value indicates the operation to perform
+	 */
+	op: PatchItemOpEnum
+
+	/**
+	 * path specifies a string format for identifying a specific value within a JSON document. It is used by all operations in patch to specify the part of the document to operate on.
+	 */
+	path: string
+
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	value?: any
+}
+
 export interface PresentationDeviceConfigEntry {
 	component: string
 	capability: string
@@ -34,6 +54,7 @@ export interface PresentationDeviceConfigEntry {
 		 */
 		step?: number
 	}[]
+	patch?: PatchItem[]
 	visibleCondition?: CapabilityVisibleCondition
 }
 

--- a/test/unit/data/presentation/presentation.ts
+++ b/test/unit/data/presentation/presentation.ts
@@ -1,6 +1,7 @@
 import {
 	CapabilityPresentationOperator,
 	CapabilityVisibleCondition,
+	PatchItemOpEnum,
 	PresentationDeviceConfig,
 	PresentationDeviceConfigEntry,
 	PresentationDPInfo,
@@ -24,6 +25,9 @@ const data = {
 				'values': [
 					{ 'key': 'keyName' },
 				],
+				'patch': [
+					{'op': PatchItemOpEnum.REPLACE, 'path': '/0/main/1/value', 'value': 'New Value'},
+				],
 				'visibleCondition': {
 					'component': 'component',
 					'version': 1,
@@ -40,6 +44,9 @@ const data = {
 				'version': 1,
 				'values': [
 					{ 'key': 'keyName' },
+				],
+				'patch': [
+					{'op': PatchItemOpEnum.REPLACE, 'path': '/0/main/1/value', 'value': 'New Value'},
 				],
 				'visibleCondition': {
 					'component': 'component',
@@ -59,6 +66,9 @@ const data = {
 			'values': [
 				{ 'key': 'keyName' },
 			],
+			'patch': [
+				{'op': PatchItemOpEnum.REPLACE, 'path': '/0/main/1/value', 'value': 'New Value'},
+			],
 			'visibleCondition': {
 				'component': 'component',
 				'version': 1,
@@ -77,6 +87,9 @@ const data = {
 				'values': [
 					{ 'key': 'keyName' },
 				],
+				'patch': [
+					{'op': PatchItemOpEnum.REPLACE, 'path': '/0/main/1/value', 'value': 'New Value'},
+				],
 				'visibleCondition': {
 					'component': 'component',
 					'version': 1,
@@ -93,6 +106,9 @@ const data = {
 				'version': 1,
 				'values': [
 					{ 'key': 'keyName' },
+				],
+				'patch': [
+					{'op': PatchItemOpEnum.REPLACE, 'path': '/0/main/1/value', 'value': 'New Value'},
 				],
 				'visibleCondition': {
 					'component': 'component',


### PR DESCRIPTION
Updated device configuration type def to include the `patch` property for overriding capability presentation values.

https://smartthings.developer.samsung.com/docs/api-ref/st-api.html#operation/createDeviceConfiguration