### PR TITLE
BREAKING CHANGE: Change from vid to presentationId

### DIFF
--- a/src/endpoint/presentation.ts
+++ b/src/endpoint/presentation.ts
@@ -103,7 +103,7 @@ export interface PresentationDeviceConfig extends PresentationDeviceConfigCreate
 	/**
 	 * The name of the manufacturer.
 	 */
-	mnmn: string
+	manufacturerName: string
 	/**
 	 * A unique identifier for the presentation of a device. This can be a
 	 * model number on some device integrations, but moving forward will
@@ -113,7 +113,7 @@ export interface PresentationDeviceConfig extends PresentationDeviceConfigCreate
 	 * You can ignore this field unless you are specifically designing a
 	 * plugin with an external detail view.
 	 */
-	vid: string
+	presentationId: string
 	/**
 	 * Information used for obtaining details page plugins on different
 	 * platforms.
@@ -123,8 +123,8 @@ export interface PresentationDeviceConfig extends PresentationDeviceConfigCreate
 
 
 export interface PresentationDevicePresentation {
-	mnmn: string
-	vid: string
+	manufacturerName: string
+	presentationId: string
 	/**
 	 * Preloaded iconId or URL used to retrieve icons to be drawn on the UI
 	 * Client.
@@ -200,8 +200,8 @@ export class PresentationEndpoint extends Endpoint {
 		return this.client.get<PresentationDeviceConfig>(`types/${profileId}/deviceconfig`, extraParams)
 	}
 
-	public get(vid: string): Promise<PresentationDeviceConfig> {
-		return this.client.get<PresentationDeviceConfig>('deviceconfig', { vid })
+	public get(presentationId: string): Promise<PresentationDeviceConfig> {
+		return this.client.get<PresentationDeviceConfig>('deviceconfig', { presentationId })
 	}
 
 	/**
@@ -213,15 +213,15 @@ export class PresentationEndpoint extends Endpoint {
 	}
 
 	/**
-	 * Get a device presentation. If mnmn is omitted the default SmartThingsCommunity mnmn is used.
-	 * @param vid The id returned from the device config create operation
-	 * @param mnmn The manufacturer name, e.g. SmartThingsCommunity
+	 * Get a device presentation. If manufacturerName is omitted the default SmartThingsCommunity manufacturerName is used.
+	 * @param presentationId The id returned from the device config create operation
+	 * @param manufacturerName The manufacturer name, e.g. SmartThingsCommunity
 	 */
-	public getPresentation(vid: string, mnmn?: string): Promise<PresentationDevicePresentation> {
-		if (mnmn) {
-			return this.client.get<PresentationDevicePresentation>('', { vid, mnmn })
+	public getPresentation(presentationId: string, manufacturerName?: string): Promise<PresentationDevicePresentation> {
+		if (manufacturerName) {
+			return this.client.get<PresentationDevicePresentation>('', { presentationId, manufacturerName })
 		} else {
-			return this.client.get<PresentationDevicePresentation>('', { vid })
+			return this.client.get<PresentationDevicePresentation>('', { presentationId })
 		}
 	}
 }

--- a/test/unit/data/presentation/presentation.ts
+++ b/test/unit/data/presentation/presentation.ts
@@ -9,8 +9,8 @@ import {
 
 
 const data = {
-	'mnmn': 'Test Manufacturer',
-	'vid': 'vendor-00',
+	'manufacturerName': 'Test Manufacturer',
+	'presentationId': 'd8469d5c-3ca2-4601-9f21-2b7a0ccd44a5',
 	'type': 'profile',
 	'dpInfo': [
 

--- a/test/unit/presentation.test.ts
+++ b/test/unit/presentation.test.ts
@@ -51,10 +51,10 @@ describe('Presentation',  () => {
 
 	it('get', async () => {
 		axios.request.mockImplementationOnce(() => Promise.resolve({status: 200, data: presentationDeviceConfiguration}))
-		const response: PresentationDeviceConfig = await client.presentation.get('vid')
+		const response: PresentationDeviceConfig = await client.presentation.get('d8469d5c-3ca2-4601-9f21-2b7a0ccd44a5')
 
 		expect(axios.request).toHaveBeenCalledTimes(1)
-		expect(axios.request).toHaveBeenCalledWith(expectedRequest('presentation/deviceconfig', { vid: 'vid' }))
+		expect(axios.request).toHaveBeenCalledWith(expectedRequest('presentation/deviceconfig', { presentationId: 'd8469d5c-3ca2-4601-9f21-2b7a0ccd44a5' }))
 		expect(response).toBe(presentationDeviceConfiguration)
 	})
 


### PR DESCRIPTION
Changed `vid` to `presentationId` and `mnmn` to `manufacturerName`.

The current API accepts either vid/mnmn or presentationId/manufacturerName and returns both in the response. However, at some point vid and mnmn will be removed from the response and no longer accepted as parameters. For that reason I think this update should be considered a breaking change. It won't actually break anything for JavaScript clients (until the API removes mnmn and vid), but it will result in an error for TypeScript clients referencing those field, as it should, since they are
eventually going away.