### PR TITLE
fix: Use POST rather than PUT for subscriptions.create

### DIFF
--- a/src/endpoint/subscriptions.ts
+++ b/src/endpoint/subscriptions.ts
@@ -255,18 +255,7 @@ export class SubscriptionsEndpoint extends Endpoint {
 	 * with an installedAppId
 	 */
 	public create(data: SubscriptionRequest, installedAppId?: string): Promise<Subscription> {
-		return this.client.put<Subscription>(`${this.installedAppId(installedAppId)}/subscriptions/`, data)
-	}
-
-	/**
-	 * Update a subscription
-	 * @param name the alphanumeric subscription name
-	 * @param data the new subscription definition
-	 * @param installedAppId the UUID of the installed app. This parameter is not required if the client id configured
-	 * with an installedAppId
-	 */
-	public update(name: string, data: SubscriptionRequest, installedAppId?: string): Promise<Subscription> {
-		return this.client.put<Subscription>(`${this.installedAppId(installedAppId)}/subscriptions/${name}`, data)
+		return this.client.post<Subscription>(`${this.installedAppId(installedAppId)}/subscriptions`, data)
 	}
 
 	/**

--- a/test/unit/data/subscriptions/post_installedapps_subscriptions.ts
+++ b/test/unit/data/subscriptions/post_installedapps_subscriptions.ts
@@ -1,0 +1,38 @@
+const request = {
+	'url': 'https://api.smartthings.com/installedapps/5336bd07-435f-4b6c-af1d-fddba55c1c24/subscriptions',
+	'method': 'post',
+	'headers': {
+		'Content-Type': 'application/json;charset=utf-8',
+		'Accept': 'application/json',
+		'Authorization': 'Bearer 52991afa-66e8-4af0-8d85-5c568ed5ba7d',
+	},
+	'data': {
+		'sourceType': 'DEVICE',
+		'device': {
+			'deviceId': '736e3903-001c-4d40-b408-ff40d162a06b',
+			'componentId': 'freezer',
+			'capability': 'temperatureMeasurement',
+			'attribute': 'temperature',
+			'stateChangeOnly': true,
+			'modes': [
+				'e34b57fb-e73a-4228-8819-e99502d17890',
+				'cfa3a42e-5f52-452e-9515-c32bcbea48ce',
+			],
+		},
+	},
+}
+const response = {
+	'id': '5e1b134b-bd85-4125-9c25-4a8291e754aa',
+	'installedAppId': 'fb05c874-cf1d-406a-930c-69a081e0eaee',
+	'sourceType': 'DEVICE',
+	'device': {
+		'componentId': 'main',
+		'deviceId': 'e457978e-5e37-43e6-979d-18112e12c961,',
+		'capability': 'contactSensor,',
+		'attribute': 'contact,',
+		'stateChangeOnly': 'true,',
+		'subscriptionName': 'contact_subscription',
+		'value': '*',
+	},
+}
+export default {request, response}

--- a/test/unit/subscriptions.test.ts
+++ b/test/unit/subscriptions.test.ts
@@ -4,11 +4,13 @@ import {
 	Count,
 	SmartThingsClient,
 	Subscription,
+	SubscriptionSource,
 } from '../../src'
 import {expectedRequest} from './helpers/utils'
 import list from './data/subscriptions/get_installedapps_subscriptions'
 import deleteOne from './data/subscriptions/delete_installedapps_subscriptions_one'
 import deleteAll from './data/subscriptions/delete_installedapps_subscriptions_all'
+import create from './data/subscriptions/post_installedapps_subscriptions'
 
 
 const client = new SmartThingsClient(
@@ -53,5 +55,25 @@ describe('Subscriptions',  () => {
 		const response: Count = await client.subscriptions.unsubscribeAll()
 		expect(axios.request).toHaveBeenCalledWith(expectedRequest(deleteAll.request))
 		expect(response.count).toEqual(3)
+	})
+
+	it('Create', async () => {
+		axios.request.mockImplementationOnce(() => Promise.resolve({status: 200, data: create.response}))
+		const response: Subscription = await client.subscriptions.create({
+			'sourceType': SubscriptionSource.DEVICE,
+			'device': {
+				'deviceId': '736e3903-001c-4d40-b408-ff40d162a06b',
+				'componentId': 'freezer',
+				'capability': 'temperatureMeasurement',
+				'attribute': 'temperature',
+				'stateChangeOnly': true,
+				'modes': [
+					'e34b57fb-e73a-4228-8819-e99502d17890',
+					'cfa3a42e-5f52-452e-9515-c32bcbea48ce',
+				],
+			},
+		})
+		expect(axios.request).toHaveBeenCalledWith(expectedRequest(create.request))
+		expect(response).toBe(create.response)
 	})
 })


### PR DESCRIPTION
Fix to issue #63 

Also removes `subscriptions.update()` function since it was included in error. There is no corresponding PUT method for subscriptions. 

Not considered a breaking change since this function, if used, would not have previously worked.