### PR TITLE
feat: Added devices.updateProfile method

### DIFF
--- a/src/endpoint/devices.ts
+++ b/src/endpoint/devices.ts
@@ -110,6 +110,10 @@ export interface DeviceUpdate {
 	label?: string
 }
 
+export interface DeviceProfileUpdate {
+	profileId: string
+}
+
 export interface DeviceCreate {
 	label?: string
 	locationId?: string // <^(?:([0-9a-fA-F]{32})|([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}))$>
@@ -368,6 +372,18 @@ export class DevicesEndpoint extends Endpoint {
 	 */
 	public update(id: string, data: DeviceUpdate): Promise<Device> {
 		return this.client.put<Device>(id, data)
+	}
+
+	/**
+	 * Update the deviceProfileId of a device. Note that currently this method can
+	 * only be called with an installedApp token with the i:deviceprofiles scope
+	 * on a device created by that app.
+	 * @param id UUID of the device
+	 * @param data the new device profile
+	 */
+	public updateProfile(id: string, data: DeviceProfileUpdate): Promise<Device> {
+		return this.client.request<Device>('put',`${id}/profile`, data, undefined,
+			{headerOverrides: {Accept: 'application/vnd.smartthings+json;v=20170916'}})
 	}
 
 	/**

--- a/test/unit/data/devices/put_devices.ts
+++ b/test/unit/data/devices/put_devices.ts
@@ -1,0 +1,41 @@
+const request = {
+	'url': 'https://api.smartthings.com/devices/6f5ea629-4c05-4a90-a244-cc129b0a80c3',
+	'method': 'put',
+	'headers': {
+		'Content-Type': 'application/json;charset=utf-8',
+		'Accept': 'application/json',
+		'Authorization': 'Bearer 52991afa-66e8-4af0-8d85-5c568ed5ba7d',
+	},
+	'data': {
+		'label': 'Living room light',
+	},
+}
+const response = {
+	'deviceId': '6f5ea629-4c05-4a90-a244-cc129b0a80c3',
+	'name': 'color.light.100x',
+	'label': 'Living room light',
+	'deviceManufacturerCode': '010F-0B01-2002',
+	'locationId': '95efee9b-6073-4871-b5ba-de6642187293',
+	'roomId': '0fd2b1ef-1b33-4a54-9153-65aca91e9660',
+	'components': [
+		{
+			'id': 'main',
+			'label': 'string',
+			'capabilities': [
+				{
+					'id': 'switch',
+					'version': 1,
+				},
+			],
+		},
+	],
+	'app': {
+		'installedAppId': '0c0b935d-0616-4441-a0bf-da7aeec3dc0a',
+		'externalId': 'Th13390',
+		'profile': {
+			'id': 'a7b3c264-2d22-416e-bca1-ca4b59a60aee',
+		},
+	},
+	'type': 'ENDPOINT_APP',
+}
+export default {request, response}

--- a/test/unit/data/devices/put_devices_profile.ts
+++ b/test/unit/data/devices/put_devices_profile.ts
@@ -1,0 +1,41 @@
+const request = {
+	'url': 'https://api.smartthings.com/devices/6f5ea629-4c05-4a90-a244-cc129b0a80c3/profile',
+	'method': 'put',
+	'headers': {
+		'Content-Type': 'application/json;charset=utf-8',
+		'Accept': 'application/vnd.smartthings+json;v=20170916',
+		'Authorization': 'Bearer 52991afa-66e8-4af0-8d85-5c568ed5ba7d',
+	},
+	'data': {
+		'profileId': '2b11d686-11e2-41f9-bff2-8aa40d9b944a',
+	},
+}
+const response = {
+	'deviceId': '6f5ea629-4c05-4a90-a244-cc129b0a80c3',
+	'name': 'color.light.100x',
+	'label': 'Living room light',
+	'deviceManufacturerCode': '010F-0B01-2002',
+	'locationId': '95efee9b-6073-4871-b5ba-de6642187293',
+	'roomId': '0fd2b1ef-1b33-4a54-9153-65aca91e9660',
+	'components': [
+		{
+			'id': 'main',
+			'label': 'string',
+			'capabilities': [
+				{
+					'id': 'switch',
+					'version': 1,
+				},
+			],
+		},
+	],
+	'app': {
+		'installedAppId': '0c0b935d-0616-4441-a0bf-da7aeec3dc0a',
+		'externalId': 'Th13390',
+		'profile': {
+			'id': '2b11d686-11e2-41f9-bff2-8aa40d9b944a',
+		},
+	},
+	'type': 'ENDPOINT_APP',
+}
+export default {request, response}

--- a/test/unit/devices.test.ts
+++ b/test/unit/devices.test.ts
@@ -23,6 +23,8 @@ import createEvents from './data/devices/post_devices_385931b6-0121-4848-bcc8-54
 import turnOn1 from './data/devices/post_devices_385931b6-0121-4848-bcc8-54cb76436de1_commands'
 import create from './data/devices/post_devices'
 import create2 from './data/devices/post_devices_2'
+import update from './data/devices/put_devices'
+import updateProfile from './data/devices/put_devices_profile'
 
 
 const authenticator = new BearerTokenAuthenticator('52991afa-66e8-4af0-8d85-5c568ed5ba7d')
@@ -182,6 +184,26 @@ describe('Devices',  () => {
 		const response: Device = await isaClient.devices.create(data)
 		expect(axios.request).toHaveBeenCalledWith(expectedRequest(create2.request))
 		expect(response).toBe(create2.response)
+	})
+
+	it('update name', async () => {
+		axios.request.mockImplementationOnce(() => Promise.resolve({ status: 200, data: update.response }))
+		const data = {
+			'label': 'Living room light',
+		}
+		const response: Device = await isaClient.devices.update('6f5ea629-4c05-4a90-a244-cc129b0a80c3', data)
+		expect(axios.request).toHaveBeenCalledWith(expectedRequest(update.request))
+		expect(response).toStrictEqual(create.response)
+	})
+
+	it('update profileId', async () => {
+		axios.request.mockImplementationOnce(() => Promise.resolve({ status: 200, data: updateProfile.response }))
+		const data = {
+			'profileId': '2b11d686-11e2-41f9-bff2-8aa40d9b944a',
+		}
+		const response: Device = await isaClient.devices.updateProfile('6f5ea629-4c05-4a90-a244-cc129b0a80c3', data)
+		expect(axios.request).toHaveBeenCalledWith(expectedRequest(updateProfile.request))
+		expect(response).toStrictEqual(updateProfile.response)
 	})
 
 	it('executeCommand', async () => {


### PR DESCRIPTION
Added new devices `updateProfile` method that allows the device profile ID of a device to be changed. This method can only be called with an installedApp token that includes the `i:deviceprofiles` scope, and only for devices created by that installedApp.