### PR TITLE
fix: enable no-floating-promises lint rule and fix issue found

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -24,6 +24,8 @@ module.exports = {
 	},
 	parserOptions: {
 		ecmaVersion: 2018,
+		tsconfigRootDir: __dirname,
+		project: ['./tsconfig.json', './tsconfig-test.json']
 	},
 	rules: {
 		indent: 'off',
@@ -79,6 +81,7 @@ module.exports = {
 			{ functions: false, classes: false, enums: false, variables: true },
 		],
 		'@typescript-eslint/no-var-requires': 'error',
+		'@typescript-eslint/no-floating-promises': 'error',
 
 		// disallow non-import statements appearing before import statements
 		'import/first': 'error',

--- a/global.d.ts
+++ b/global.d.ts
@@ -1,0 +1,1 @@
+declare module 'http-signature'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1473,101 +1473,104 @@
 			}
 		},
 		"@octokit/auth-token": {
-			"version": "2.4.2",
-			"resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.4.2.tgz",
-			"integrity": "sha512-jE/lE/IKIz2v1+/P0u4fJqv0kYwXOTujKemJMFr6FeopsxlIK3+wKDCJGnysg81XID5TgZQbIfuJ5J0lnTiuyQ==",
+			"version": "2.4.4",
+			"resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.4.4.tgz",
+			"integrity": "sha512-LNfGu3Ro9uFAYh10MUZVaT7X2CnNm2C8IDQmabx+3DygYIQjs9FwzFAHN/0t6mu5HEPhxcb1XOuxdpY82vCg2Q==",
 			"dev": true,
 			"requires": {
-				"@octokit/types": "^5.0.0"
+				"@octokit/types": "^6.0.0"
 			}
 		},
 		"@octokit/core": {
-			"version": "2.5.4",
-			"resolved": "https://registry.npmjs.org/@octokit/core/-/core-2.5.4.tgz",
-			"integrity": "sha512-HCp8yKQfTITYK+Nd09MHzAlP1v3Ii/oCohv0/TW9rhSLvzb98BOVs2QmVYuloE6a3l6LsfyGIwb6Pc4ycgWlIQ==",
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.2.2.tgz",
+			"integrity": "sha512-cZEP6dC8xpepbAqtdS1GgX88omLer8VQegw5BpQ5fbSrkxgY9Y9K7ratu8ezAd9bD0GVOR1GVWiRzYdxiprU1w==",
 			"dev": true,
 			"requires": {
 				"@octokit/auth-token": "^2.4.0",
 				"@octokit/graphql": "^4.3.1",
 				"@octokit/request": "^5.4.0",
-				"@octokit/types": "^5.0.0",
+				"@octokit/types": "^6.0.0",
 				"before-after-hook": "^2.1.0",
-				"universal-user-agent": "^5.0.0"
+				"universal-user-agent": "^6.0.0"
 			}
 		},
 		"@octokit/endpoint": {
-			"version": "6.0.5",
-			"resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.5.tgz",
-			"integrity": "sha512-70K5u6zd45ItOny6aHQAsea8HHQjlQq85yqOMe+Aj8dkhN2qSJ9T+Q3YjUjEYfPRBcuUWNgMn62DQnP/4LAIiQ==",
+			"version": "6.0.10",
+			"resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.10.tgz",
+			"integrity": "sha512-9+Xef8nT7OKZglfkOMm7IL6VwxXUQyR7DUSU0LH/F7VNqs8vyd7es5pTfz9E7DwUIx7R3pGscxu1EBhYljyu7Q==",
 			"dev": true,
 			"requires": {
-				"@octokit/types": "^5.0.0",
-				"is-plain-object": "^4.0.0",
+				"@octokit/types": "^6.0.0",
+				"is-plain-object": "^5.0.0",
 				"universal-user-agent": "^6.0.0"
 			},
 			"dependencies": {
 				"is-plain-object": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-4.1.1.tgz",
-					"integrity": "sha512-5Aw8LLVsDlZsETVMhoMXzqsXwQqr/0vlnBYzIXJbYo2F4yYlhLHs+Ez7Bod7IIQKWkJbJfxrWD7pA1Dw1TKrwA==",
-					"dev": true
-				},
-				"universal-user-agent": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
-					"integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w==",
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+					"integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
 					"dev": true
 				}
 			}
 		},
 		"@octokit/graphql": {
-			"version": "4.5.3",
-			"resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.5.3.tgz",
-			"integrity": "sha512-JyYvi3j2tOb5ofASEpcg1Advs07H+Ag+I+ez7buuZfNVAmh1IYcDTuxd4gnYH8S2PSGu+f5IdDGxMmkK+5zsdA==",
+			"version": "4.5.8",
+			"resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.5.8.tgz",
+			"integrity": "sha512-WnCtNXWOrupfPJgXe+vSmprZJUr0VIu14G58PMlkWGj3cH+KLZEfKMmbUQ6C3Wwx6fdhzVW1CD5RTnBdUHxhhA==",
 			"dev": true,
 			"requires": {
 				"@octokit/request": "^5.3.0",
-				"@octokit/types": "^5.0.0",
+				"@octokit/types": "^6.0.0",
 				"universal-user-agent": "^6.0.0"
+			}
+		},
+		"@octokit/openapi-types": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-1.2.2.tgz",
+			"integrity": "sha512-vrKDLd/Rq4IE16oT+jJkDBx0r29NFkdkU8GwqVSP4RajsAvP23CMGtFhVK0pedUhAiMvG1bGnFcTC/xCKaKgmw==",
+			"dev": true
+		},
+		"@octokit/plugin-paginate-rest": {
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.6.0.tgz",
+			"integrity": "sha512-o+O8c1PqsC5++BHXfMZabRRsBIVb34tXPWyQLyp2IXq5MmkxdipS7TXM4Y9ldL1PzY9CTrCsn/lzFFJGM3oRRA==",
+			"dev": true,
+			"requires": {
+				"@octokit/types": "^5.5.0"
 			},
 			"dependencies": {
-				"universal-user-agent": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
-					"integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w==",
-					"dev": true
+				"@octokit/types": {
+					"version": "5.5.0",
+					"resolved": "https://registry.npmjs.org/@octokit/types/-/types-5.5.0.tgz",
+					"integrity": "sha512-UZ1pErDue6bZNjYOotCNveTXArOMZQFG6hKJfOnGnulVCMcVVi7YIIuuR4WfBhjo7zgpmzn/BkPDnUXtNx+PcQ==",
+					"dev": true,
+					"requires": {
+						"@types/node": ">= 8"
+					}
 				}
 			}
 		},
-		"@octokit/plugin-paginate-rest": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.3.0.tgz",
-			"integrity": "sha512-Ye2ZJreP0ZlqJQz8fz+hXvrEAEYK4ay7br1eDpWzr6j76VXs/gKqxFcH8qRzkB3fo/2xh4Vy9VtGii4ZDc9qlA==",
-			"dev": true,
-			"requires": {
-				"@octokit/types": "^5.2.0"
-			}
-		},
 		"@octokit/plugin-request-log": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.0.tgz",
-			"integrity": "sha512-ywoxP68aOT3zHCLgWZgwUJatiENeHE7xJzYjfz8WI0goynp96wETBF+d95b8g/uL4QmS6owPVlaxiz3wyMAzcw==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.2.tgz",
+			"integrity": "sha512-oTJSNAmBqyDR41uSMunLQKMX0jmEXbwD1fpz8FG27lScV3RhtGfBa1/BBLym+PxcC16IBlF7KH9vP1BUYxA+Eg==",
 			"dev": true
 		},
 		"@octokit/plugin-rest-endpoint-methods": {
-			"version": "3.17.0",
-			"resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-3.17.0.tgz",
-			"integrity": "sha512-NFV3vq7GgoO2TrkyBRUOwflkfTYkFKS0tLAPym7RNpkwLCttqShaEGjthOsPEEL+7LFcYv3mU24+F2yVd3npmg==",
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-4.2.1.tgz",
+			"integrity": "sha512-QyFr4Bv807Pt1DXZOC5a7L5aFdrwz71UHTYoHVajYV5hsqffWm8FUl9+O7nxRu5PDMtB/IKrhFqTmdBTK5cx+A==",
 			"dev": true,
 			"requires": {
-				"@octokit/types": "^4.1.6",
+				"@octokit/types": "^5.5.0",
 				"deprecation": "^2.3.1"
 			},
 			"dependencies": {
 				"@octokit/types": {
-					"version": "4.1.10",
-					"resolved": "https://registry.npmjs.org/@octokit/types/-/types-4.1.10.tgz",
-					"integrity": "sha512-/wbFy1cUIE5eICcg0wTKGXMlKSbaAxEr00qaBXzscLXpqhcwgXeS6P8O0pkysBhRfyjkKjJaYrvR1ExMO5eOXQ==",
+					"version": "5.5.0",
+					"resolved": "https://registry.npmjs.org/@octokit/types/-/types-5.5.0.tgz",
+					"integrity": "sha512-UZ1pErDue6bZNjYOotCNveTXArOMZQFG6hKJfOnGnulVCMcVVi7YIIuuR4WfBhjo7zgpmzn/BkPDnUXtNx+PcQ==",
 					"dev": true,
 					"requires": {
 						"@types/node": ">= 8"
@@ -1576,64 +1579,59 @@
 			}
 		},
 		"@octokit/request": {
-			"version": "5.4.7",
-			"resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.4.7.tgz",
-			"integrity": "sha512-FN22xUDP0i0uF38YMbOfx6TotpcENP5W8yJM1e/LieGXn6IoRxDMnBf7tx5RKSW4xuUZ/1P04NFZy5iY3Rax1A==",
+			"version": "5.4.11",
+			"resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.4.11.tgz",
+			"integrity": "sha512-vskebNjuz4oTdPIv+9cQjHvjk8vjrMv2fOmSo6zr7IIaFHeVsJlG/C07MXiSS/+g/qU1GHjkPG1XW3faz57EoQ==",
 			"dev": true,
 			"requires": {
 				"@octokit/endpoint": "^6.0.1",
 				"@octokit/request-error": "^2.0.0",
-				"@octokit/types": "^5.0.0",
+				"@octokit/types": "^6.0.0",
 				"deprecation": "^2.0.0",
-				"is-plain-object": "^4.0.0",
-				"node-fetch": "^2.3.0",
+				"is-plain-object": "^5.0.0",
+				"node-fetch": "^2.6.1",
 				"once": "^1.4.0",
 				"universal-user-agent": "^6.0.0"
 			},
 			"dependencies": {
 				"is-plain-object": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-4.1.1.tgz",
-					"integrity": "sha512-5Aw8LLVsDlZsETVMhoMXzqsXwQqr/0vlnBYzIXJbYo2F4yYlhLHs+Ez7Bod7IIQKWkJbJfxrWD7pA1Dw1TKrwA==",
-					"dev": true
-				},
-				"universal-user-agent": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
-					"integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w==",
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+					"integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
 					"dev": true
 				}
 			}
 		},
 		"@octokit/request-error": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.0.2.tgz",
-			"integrity": "sha512-2BrmnvVSV1MXQvEkrb9zwzP0wXFNbPJij922kYBTLIlIafukrGOb+ABBT2+c6wZiuyWDH1K1zmjGQ0toN/wMWw==",
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.0.4.tgz",
+			"integrity": "sha512-LjkSiTbsxIErBiRh5wSZvpZqT4t0/c9+4dOe0PII+6jXR+oj/h66s7E4a/MghV7iT8W9ffoQ5Skoxzs96+gBPA==",
 			"dev": true,
 			"requires": {
-				"@octokit/types": "^5.0.1",
+				"@octokit/types": "^6.0.0",
 				"deprecation": "^2.0.0",
 				"once": "^1.4.0"
 			}
 		},
 		"@octokit/rest": {
-			"version": "17.11.2",
-			"resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-17.11.2.tgz",
-			"integrity": "sha512-4jTmn8WossTUaLfNDfXk4fVJgbz5JgZE8eCs4BvIb52lvIH8rpVMD1fgRCrHbSd6LRPE5JFZSfAEtszrOq3ZFQ==",
+			"version": "18.0.9",
+			"resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-18.0.9.tgz",
+			"integrity": "sha512-CC5+cIx974Ygx9lQNfUn7/oXDQ9kqGiKUC6j1A9bAVZZ7aoTF8K6yxu0pQhQrLBwSl92J6Z3iVDhGhGFgISCZg==",
 			"dev": true,
 			"requires": {
-				"@octokit/core": "^2.4.3",
+				"@octokit/core": "^3.0.0",
 				"@octokit/plugin-paginate-rest": "^2.2.0",
 				"@octokit/plugin-request-log": "^1.0.0",
-				"@octokit/plugin-rest-endpoint-methods": "3.17.0"
+				"@octokit/plugin-rest-endpoint-methods": "4.2.1"
 			}
 		},
 		"@octokit/types": {
-			"version": "5.2.1",
-			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-5.2.1.tgz",
-			"integrity": "sha512-PugtgEw8u++zAyBpDpSkR8K1OsT2l8QWp3ECL6bZHFoq9PfHDoKeGFWSuX2Z+Ghy93k1fkKf8tsmqNBv+8dEfQ==",
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.0.1.tgz",
+			"integrity": "sha512-H/DnTKC+U09en2GFLH/MfAPNDaYb1isieD4Hx4NLpEt/I1PgtZP/8a+Ehc/j9GHuVF/UvGtOVD8AF9XXvws53w==",
 			"dev": true,
 			"requires": {
+				"@octokit/openapi-types": "^1.2.0",
 				"@types/node": ">= 8"
 			}
 		},
@@ -1653,12 +1651,12 @@
 			},
 			"dependencies": {
 				"debug": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"version": "4.3.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+					"integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
 					"dev": true,
 					"requires": {
-						"ms": "^2.1.1"
+						"ms": "2.1.2"
 					}
 				},
 				"ms": {
@@ -1791,12 +1789,12 @@
 			}
 		},
 		"@semantic-release/github": {
-			"version": "7.0.7",
-			"resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-7.0.7.tgz",
-			"integrity": "sha512-Sai2UucYQ+5rJzKVEVJ4eiZNDdoo0/CzfpValBdeU5h97uJE7t4CoBTmUWkiXlPOx46CSw1+JhI+PHC1PUxVZw==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-7.2.0.tgz",
+			"integrity": "sha512-tMRnWiiWb43whRHvbDGXq4DGEbKRi56glDpXDJZit4PIiwDPX7Kx3QzmwRtDOcG+8lcpGjpdPabYZ9NBxoI2mw==",
 			"dev": true,
 			"requires": {
-				"@octokit/rest": "^17.0.0",
+				"@octokit/rest": "^18.0.0",
 				"@semantic-release/error": "^2.2.0",
 				"aggregate-error": "^3.0.0",
 				"bottleneck": "^2.18.1",
@@ -1815,12 +1813,12 @@
 			},
 			"dependencies": {
 				"debug": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"version": "4.3.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+					"integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
 					"dev": true,
 					"requires": {
-						"ms": "^2.1.1"
+						"ms": "2.1.2"
 					}
 				},
 				"fs-extra": {
@@ -1836,13 +1834,21 @@
 					}
 				},
 				"jsonfile": {
-					"version": "6.0.1",
-					"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.0.1.tgz",
-					"integrity": "sha512-jR2b5v7d2vIOust+w3wtFKZIfpC2pnRmFAhAC/BuweZFQR8qZzxH1OyrQ10HmdVYiXWkYUqPVsz91cG7EL2FBg==",
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+					"integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
 					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.6",
-						"universalify": "^1.0.0"
+						"universalify": "^2.0.0"
+					},
+					"dependencies": {
+						"universalify": {
+							"version": "2.0.0",
+							"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+							"integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+							"dev": true
+						}
 					}
 				},
 				"ms": {
@@ -1860,9 +1866,9 @@
 			}
 		},
 		"@semantic-release/npm": {
-			"version": "7.0.5",
-			"resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-7.0.5.tgz",
-			"integrity": "sha512-D+oEmsx9aHE1q806NFQwSC9KdBO8ri/VO99eEz0wWbX2jyLqVyWr7t0IjKC8aSnkkQswg/4KN/ZjfF6iz1XOpw==",
+			"version": "7.0.8",
+			"resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-7.0.8.tgz",
+			"integrity": "sha512-8c1TLwKB/xT5E1FNs5l4GFtaNTznHesJk7tw3pGSlVxRqDXa1EZI+DfziZlO58Wk3PpS2ecu661kvBdz9aMgYQ==",
 			"dev": true,
 			"requires": {
 				"@semantic-release/error": "^2.2.0",
@@ -1872,12 +1878,12 @@
 				"lodash": "^4.17.15",
 				"nerf-dart": "^1.0.0",
 				"normalize-url": "^5.0.0",
-				"npm": "^6.10.3",
+				"npm": "^6.14.8",
 				"rc": "^1.2.8",
 				"read-pkg": "^5.0.0",
 				"registry-auth-token": "^4.0.0",
 				"semver": "^7.1.2",
-				"tempy": "^0.5.0"
+				"tempy": "^1.0.0"
 			},
 			"dependencies": {
 				"cross-spawn": {
@@ -1892,9 +1898,9 @@
 					}
 				},
 				"execa": {
-					"version": "4.0.3",
-					"resolved": "https://registry.npmjs.org/execa/-/execa-4.0.3.tgz",
-					"integrity": "sha512-WFDXGHckXPWZX19t1kCsXzOpqX9LWYNqn4C+HqZlk/V0imTkzJZqf87ZBhvpHaftERYknpk0fjSylnXVlVgI0A==",
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
+					"integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
 					"dev": true,
 					"requires": {
 						"cross-spawn": "^7.0.0",
@@ -1921,9 +1927,9 @@
 					}
 				},
 				"get-stream": {
-					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
-					"integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+					"integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
 					"dev": true,
 					"requires": {
 						"pump": "^3.0.0"
@@ -1936,13 +1942,21 @@
 					"dev": true
 				},
 				"jsonfile": {
-					"version": "6.0.1",
-					"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.0.1.tgz",
-					"integrity": "sha512-jR2b5v7d2vIOust+w3wtFKZIfpC2pnRmFAhAC/BuweZFQR8qZzxH1OyrQ10HmdVYiXWkYUqPVsz91cG7EL2FBg==",
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+					"integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
 					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.6",
-						"universalify": "^1.0.0"
+						"universalify": "^2.0.0"
+					},
+					"dependencies": {
+						"universalify": {
+							"version": "2.0.0",
+							"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+							"integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+							"dev": true
+						}
 					}
 				},
 				"npm-run-path": {
@@ -1955,14 +1969,14 @@
 					}
 				},
 				"parse-json": {
-					"version": "5.0.1",
-					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.1.tgz",
-					"integrity": "sha512-ztoZ4/DYeXQq4E21v169sC8qWINGpcosGv9XhTDvg9/hWvx/zrFkc9BiWxR58OJLHGk28j5BL0SDLeV2WmFZlQ==",
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.1.0.tgz",
+					"integrity": "sha512-+mi/lmVVNKFNVyLXV31ERiy2CY5E1/F6QtJFEzoChPRwwngMNXRDQ9GJ5WdE2Z2P4AujsOi0/+2qHID68KwfIQ==",
 					"dev": true,
 					"requires": {
 						"@babel/code-frame": "^7.0.0",
 						"error-ex": "^1.3.1",
-						"json-parse-better-errors": "^1.0.1",
+						"json-parse-even-better-errors": "^2.3.0",
 						"lines-and-columns": "^1.1.6"
 					}
 				},
@@ -1985,10 +1999,13 @@
 					}
 				},
 				"semver": {
-					"version": "7.3.2",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
-					"integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
-					"dev": true
+					"version": "7.3.4",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
+					"integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+					"dev": true,
+					"requires": {
+						"lru-cache": "^6.0.0"
+					}
 				},
 				"shebang-command": {
 					"version": "2.0.0",
@@ -2047,12 +2064,12 @@
 			},
 			"dependencies": {
 				"debug": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"version": "4.3.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+					"integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
 					"dev": true,
 					"requires": {
-						"ms": "^2.1.1"
+						"ms": "2.1.2"
 					}
 				},
 				"find-up": {
@@ -2066,9 +2083,9 @@
 					}
 				},
 				"get-stream": {
-					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
-					"integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+					"integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
 					"dev": true,
 					"requires": {
 						"pump": "^3.0.0"
@@ -2114,14 +2131,14 @@
 					"dev": true
 				},
 				"parse-json": {
-					"version": "5.0.1",
-					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.1.tgz",
-					"integrity": "sha512-ztoZ4/DYeXQq4E21v169sC8qWINGpcosGv9XhTDvg9/hWvx/zrFkc9BiWxR58OJLHGk28j5BL0SDLeV2WmFZlQ==",
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.1.0.tgz",
+					"integrity": "sha512-+mi/lmVVNKFNVyLXV31ERiy2CY5E1/F6QtJFEzoChPRwwngMNXRDQ9GJ5WdE2Z2P4AujsOi0/+2qHID68KwfIQ==",
 					"dev": true,
 					"requires": {
 						"@babel/code-frame": "^7.0.0",
 						"error-ex": "^1.3.1",
-						"json-parse-better-errors": "^1.0.1",
+						"json-parse-even-better-errors": "^2.3.0",
 						"lines-and-columns": "^1.1.6"
 					}
 				},
@@ -2301,9 +2318,9 @@
 			"dev": true
 		},
 		"@types/minimist": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.0.tgz",
-			"integrity": "sha1-aaI6OtKcrwCX8G7aWbNh7i8GOfY=",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.1.tgz",
+			"integrity": "sha512-fZQQafSREFyuZcdWFAExYjBiCL7AUCdgsk80iO0q4yihYYdcIiH28CcuPTGFgLOCC8RlW49GSQxdHwZP+I7CNg==",
 			"dev": true
 		},
 		"@types/node": {
@@ -2491,21 +2508,21 @@
 			"dev": true
 		},
 		"agent-base": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.1.tgz",
-			"integrity": "sha512-01q25QQDwLSsyfhrKbn8yuur+JNw0H+0Y4JiGIKd3z9aYk/w/2kxD/Upc+t2ZBBSUNff50VjPsSW2YxM8QYKVg==",
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+			"integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
 			"dev": true,
 			"requires": {
 				"debug": "4"
 			},
 			"dependencies": {
 				"debug": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"version": "4.3.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+					"integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
 					"dev": true,
 					"requires": {
-						"ms": "^2.1.1"
+						"ms": "2.1.2"
 					}
 				},
 				"ms": {
@@ -2659,9 +2676,9 @@
 			}
 		},
 		"arrify": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
-			"integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+			"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
 			"dev": true
 		},
 		"asn1": {
@@ -3272,64 +3289,37 @@
 			"dev": true
 		},
 		"conventional-changelog-angular": {
-			"version": "5.0.11",
-			"resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-5.0.11.tgz",
-			"integrity": "sha512-nSLypht/1yEflhuTogC03i7DX7sOrXGsRn14g131Potqi6cbGbGEE9PSDEHKldabB6N76HiSyw9Ph+kLmC04Qw==",
+			"version": "5.0.12",
+			"resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-5.0.12.tgz",
+			"integrity": "sha512-5GLsbnkR/7A89RyHLvvoExbiGbd9xKdKqDTrArnPbOqBqG/2wIosu0fHwpeIRI8Tl94MhVNBXcLJZl92ZQ5USw==",
 			"dev": true,
 			"requires": {
 				"compare-func": "^2.0.0",
 				"q": "^1.5.1"
-			},
-			"dependencies": {
-				"compare-func": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/compare-func/-/compare-func-2.0.0.tgz",
-					"integrity": "sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==",
-					"dev": true,
-					"requires": {
-						"array-ify": "^1.0.0",
-						"dot-prop": "^5.1.0"
-					}
-				},
-				"dot-prop": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.2.0.tgz",
-					"integrity": "sha512-uEUyaDKoSQ1M4Oq8l45hSE26SnTxL6snNnqvK/VWx5wJhmff5z0FUVJDKDanor/6w3kzE3i7XZOk+7wC0EXr1A==",
-					"dev": true,
-					"requires": {
-						"is-obj": "^2.0.0"
-					}
-				},
-				"is-obj": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
-					"integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
-					"dev": true
-				}
 			}
 		},
 		"conventional-changelog-writer": {
-			"version": "4.0.17",
-			"resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-4.0.17.tgz",
-			"integrity": "sha512-IKQuK3bib/n032KWaSb8YlBFds+aLmzENtnKtxJy3+HqDq5kohu3g/UdNbIHeJWygfnEbZjnCKFxAW0y7ArZAw==",
+			"version": "4.0.18",
+			"resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-4.0.18.tgz",
+			"integrity": "sha512-mAQDCKyB9HsE8Ko5cCM1Jn1AWxXPYV0v8dFPabZRkvsiWUul2YyAqbIaoMKF88Zf2ffnOPSvKhboLf3fnjo5/A==",
 			"dev": true,
 			"requires": {
 				"compare-func": "^2.0.0",
-				"conventional-commits-filter": "^2.0.6",
+				"conventional-commits-filter": "^2.0.7",
 				"dateformat": "^3.0.0",
 				"handlebars": "^4.7.6",
 				"json-stringify-safe": "^5.0.1",
 				"lodash": "^4.17.15",
-				"meow": "^7.0.0",
+				"meow": "^8.0.0",
 				"semver": "^6.0.0",
 				"split": "^1.0.0",
-				"through2": "^3.0.0"
+				"through2": "^4.0.0"
 			}
 		},
 		"conventional-commits-filter": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-2.0.6.tgz",
-			"integrity": "sha512-4g+sw8+KA50/Qwzfr0hL5k5NWxqtrOVw4DDk3/h6L85a9Gz0/Eqp3oP+CWCNfesBvZZZEFHF7OTEbRe+yYSyKw==",
+			"version": "2.0.7",
+			"resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-2.0.7.tgz",
+			"integrity": "sha512-ASS9SamOP4TbCClsRHxIHXRfcGCnIoQqkvAzCSbZzTFLfcTqJVugB0agRgsEELsqaeWgsXv513eS116wnlSSPA==",
 			"dev": true,
 			"requires": {
 				"lodash.ismatch": "^4.4.0",
@@ -3337,17 +3327,17 @@
 			}
 		},
 		"conventional-commits-parser": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-3.1.0.tgz",
-			"integrity": "sha512-RSo5S0WIwXZiRxUGTPuYFbqvrR4vpJ1BDdTlthFgvHt5kEdnd1+pdvwWphWn57/oIl4V72NMmOocFqqJ8mFFhA==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-3.2.0.tgz",
+			"integrity": "sha512-XmJiXPxsF0JhAKyfA2Nn+rZwYKJ60nanlbSWwwkGwLQFbugsc0gv1rzc7VbbUWAzJfR1qR87/pNgv9NgmxtBMQ==",
 			"dev": true,
 			"requires": {
 				"JSONStream": "^1.0.4",
 				"is-text-path": "^1.0.1",
 				"lodash": "^4.17.15",
-				"meow": "^7.0.0",
+				"meow": "^8.0.0",
 				"split2": "^2.0.0",
-				"through2": "^3.0.0",
+				"through2": "^4.0.0",
 				"trim-off-newlines": "^1.0.0"
 			}
 		},
@@ -3385,14 +3375,14 @@
 			},
 			"dependencies": {
 				"parse-json": {
-					"version": "5.0.1",
-					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.1.tgz",
-					"integrity": "sha512-ztoZ4/DYeXQq4E21v169sC8qWINGpcosGv9XhTDvg9/hWvx/zrFkc9BiWxR58OJLHGk28j5BL0SDLeV2WmFZlQ==",
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.1.0.tgz",
+					"integrity": "sha512-+mi/lmVVNKFNVyLXV31ERiy2CY5E1/F6QtJFEzoChPRwwngMNXRDQ9GJ5WdE2Z2P4AujsOi0/+2qHID68KwfIQ==",
 					"dev": true,
 					"requires": {
 						"@babel/code-frame": "^7.0.0",
 						"error-ex": "^1.3.1",
-						"json-parse-better-errors": "^1.0.1",
+						"json-parse-even-better-errors": "^2.3.0",
 						"lines-and-columns": "^1.1.6"
 					}
 				},
@@ -3591,6 +3581,48 @@
 				}
 			}
 		},
+		"del": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/del/-/del-6.0.0.tgz",
+			"integrity": "sha512-1shh9DQ23L16oXSZKB2JxpL7iMy2E0S9d517ptA1P8iw0alkPtQcrKH7ru31rYtKwF499HkTu+DRzq3TCKDFRQ==",
+			"dev": true,
+			"requires": {
+				"globby": "^11.0.1",
+				"graceful-fs": "^4.2.4",
+				"is-glob": "^4.0.1",
+				"is-path-cwd": "^2.2.0",
+				"is-path-inside": "^3.0.2",
+				"p-map": "^4.0.0",
+				"rimraf": "^3.0.2",
+				"slash": "^3.0.0"
+			},
+			"dependencies": {
+				"graceful-fs": {
+					"version": "4.2.4",
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+					"integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+					"dev": true
+				},
+				"p-map": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
+					"integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
+					"dev": true,
+					"requires": {
+						"aggregate-error": "^3.0.0"
+					}
+				},
+				"rimraf": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+					"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+					"dev": true,
+					"requires": {
+						"glob": "^7.1.3"
+					}
+				}
+			}
+		},
 		"delayed-stream": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -3659,9 +3691,9 @@
 			}
 		},
 		"dot-prop": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.2.0.tgz",
-			"integrity": "sha512-uEUyaDKoSQ1M4Oq8l45hSE26SnTxL6snNnqvK/VWx5wJhmff5z0FUVJDKDanor/6w3kzE3i7XZOk+7wC0EXr1A==",
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
+			"integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
 			"dev": true,
 			"requires": {
 				"is-obj": "^2.0.0"
@@ -3728,9 +3760,9 @@
 					}
 				},
 				"execa": {
-					"version": "4.0.3",
-					"resolved": "https://registry.npmjs.org/execa/-/execa-4.0.3.tgz",
-					"integrity": "sha512-WFDXGHckXPWZX19t1kCsXzOpqX9LWYNqn4C+HqZlk/V0imTkzJZqf87ZBhvpHaftERYknpk0fjSylnXVlVgI0A==",
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
+					"integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
 					"dev": true,
 					"requires": {
 						"cross-spawn": "^7.0.0",
@@ -3745,9 +3777,9 @@
 					}
 				},
 				"get-stream": {
-					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
-					"integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+					"integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
 					"dev": true,
 					"requires": {
 						"pump": "^3.0.0"
@@ -4446,9 +4478,9 @@
 			"dev": true
 		},
 		"fastq": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.8.0.tgz",
-			"integrity": "sha512-SMIZoZdLh/fgofivvIkmknUXyPnvxRE3DhtZ5Me3Mrsk5gyPL42F0xr51TdRXskBxHfMp+07bcYzfsYEsSQA9Q==",
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.9.0.tgz",
+			"integrity": "sha512-i7FVWL8HhVY+CTkwFxkN2mk3h+787ixS5S63eb78diVRc1MCssarHq3W5cj0av7YDSwmaV928RNag+U1etRQ7w==",
 			"dev": true,
 			"requires": {
 				"reusify": "^1.0.4"
@@ -4927,12 +4959,12 @@
 			},
 			"dependencies": {
 				"debug": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"version": "4.3.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+					"integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
 					"dev": true,
 					"requires": {
-						"ms": "^2.1.1"
+						"ms": "2.1.2"
 					}
 				},
 				"ms": {
@@ -4964,12 +4996,12 @@
 			},
 			"dependencies": {
 				"debug": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"version": "4.3.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+					"integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
 					"dev": true,
 					"requires": {
-						"ms": "^2.1.1"
+						"ms": "2.1.2"
 					}
 				},
 				"ms": {
@@ -5283,6 +5315,15 @@
 				"ci-info": "^2.0.0"
 			}
 		},
+		"is-core-module": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.2.0.tgz",
+			"integrity": "sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==",
+			"dev": true,
+			"requires": {
+				"has": "^1.0.3"
+			}
+		},
 		"is-data-descriptor": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
@@ -5378,6 +5419,18 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
 			"integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
+			"dev": true
+		},
+		"is-path-cwd": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-2.2.0.tgz",
+			"integrity": "sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ==",
+			"dev": true
+		},
+		"is-path-inside": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.2.tgz",
+			"integrity": "sha512-/2UGPSgmtqwo1ktx8NDHjuPwZWmHhO+gj0f93EkhLB5RgW9RZevWYYlIkS6zePc6U2WpOdQYIwHe9YC4DWEBVg==",
 			"dev": true
 		},
 		"is-plain-obj": {
@@ -8247,12 +8300,6 @@
 			"integrity": "sha512-oxMeX/Y35PNFuZoHp+jUj5OSEmLCaIH4KTFJh7a93cHBoFmpw2IoPs22VIz7vyO2YUnx2Tn9dzIwO2P/4quIRg==",
 			"dev": true
 		},
-		"macos-release": {
-			"version": "2.4.1",
-			"resolved": "https://registry.npmjs.org/macos-release/-/macos-release-2.4.1.tgz",
-			"integrity": "sha512-H/QHeBIN1fIGJX517pvK8IEK53yQOW7YcEI55oYtgjDdoCQQz7eJS94qt5kNrscReEyuD/JcdFCm2XBEcGOITg==",
-			"dev": true
-		},
 		"make-dir": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -8319,12 +8366,11 @@
 			},
 			"dependencies": {
 				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
 					"dev": true,
 					"requires": {
-						"@types/color-name": "^1.1.1",
 						"color-convert": "^2.0.1"
 					}
 				},
@@ -8360,9 +8406,9 @@
 					"dev": true
 				},
 				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
 					"dev": true,
 					"requires": {
 						"has-flag": "^4.0.0"
@@ -8371,32 +8417,24 @@
 			}
 		},
 		"meow": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/meow/-/meow-7.0.1.tgz",
-			"integrity": "sha512-tBKIQqVrAHqwit0vfuFPY3LlzJYkEOFyKa3bPgxzNl6q/RtN8KQ+ALYEASYuFayzSAsjlhXj/JZ10rH85Q6TUw==",
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/meow/-/meow-8.0.0.tgz",
+			"integrity": "sha512-nbsTRz2fwniJBFgUkcdISq8y/q9n9VbiHYbfwklFh5V4V2uAcxtKQkDc0yCLPM/kP0d+inZBewn3zJqewHE7kg==",
 			"dev": true,
 			"requires": {
 				"@types/minimist": "^1.2.0",
-				"arrify": "^2.0.1",
-				"camelcase": "^6.0.0",
 				"camelcase-keys": "^6.2.2",
 				"decamelize-keys": "^1.1.0",
 				"hard-rejection": "^2.1.0",
-				"minimist-options": "^4.0.2",
-				"normalize-package-data": "^2.5.0",
+				"minimist-options": "4.1.0",
+				"normalize-package-data": "^3.0.0",
 				"read-pkg-up": "^7.0.1",
 				"redent": "^3.0.0",
 				"trim-newlines": "^3.0.0",
-				"type-fest": "^0.13.1",
-				"yargs-parser": "^18.1.3"
+				"type-fest": "^0.18.0",
+				"yargs-parser": "^20.2.3"
 			},
 			"dependencies": {
-				"camelcase": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.0.0.tgz",
-					"integrity": "sha512-8KMDF1Vz2gzOq54ONPJS65IvTUaB1cHJ2DMM7MbPmLZljDH1qpzzLsWdiN9pHh6qvkRVDTi/07+eNGch/oLU4w==",
-					"dev": true
-				},
 				"find-up": {
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -8407,6 +8445,15 @@
 						"path-exists": "^4.0.0"
 					}
 				},
+				"hosted-git-info": {
+					"version": "3.0.7",
+					"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-3.0.7.tgz",
+					"integrity": "sha512-fWqc0IcuXs+BmE9orLDyVykAG9GJtGLGuZAAqgcckPgv5xad4AcXGIv8galtQvlwutxSlaMcdw7BUtq2EIvqCQ==",
+					"dev": true,
+					"requires": {
+						"lru-cache": "^6.0.0"
+					}
+				},
 				"locate-path": {
 					"version": "5.0.0",
 					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
@@ -8414,6 +8461,18 @@
 					"dev": true,
 					"requires": {
 						"p-locate": "^4.1.0"
+					}
+				},
+				"normalize-package-data": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.0.tgz",
+					"integrity": "sha512-6lUjEI0d3v6kFrtgA/lOx4zHCWULXsFNIjHolnZCKCTLA6m/G625cdn3O7eNmT0iD3jfo6HZ9cdImGZwf21prw==",
+					"dev": true,
+					"requires": {
+						"hosted-git-info": "^3.0.6",
+						"resolve": "^1.17.0",
+						"semver": "^7.3.2",
+						"validate-npm-package-license": "^3.0.1"
 					}
 				},
 				"p-limit": {
@@ -8441,14 +8500,14 @@
 					"dev": true
 				},
 				"parse-json": {
-					"version": "5.0.1",
-					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.1.tgz",
-					"integrity": "sha512-ztoZ4/DYeXQq4E21v169sC8qWINGpcosGv9XhTDvg9/hWvx/zrFkc9BiWxR58OJLHGk28j5BL0SDLeV2WmFZlQ==",
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.1.0.tgz",
+					"integrity": "sha512-+mi/lmVVNKFNVyLXV31ERiy2CY5E1/F6QtJFEzoChPRwwngMNXRDQ9GJ5WdE2Z2P4AujsOi0/+2qHID68KwfIQ==",
 					"dev": true,
 					"requires": {
 						"@babel/code-frame": "^7.0.0",
 						"error-ex": "^1.3.1",
-						"json-parse-better-errors": "^1.0.1",
+						"json-parse-even-better-errors": "^2.3.0",
 						"lines-and-columns": "^1.1.6"
 					}
 				},
@@ -8470,6 +8529,30 @@
 						"type-fest": "^0.6.0"
 					},
 					"dependencies": {
+						"hosted-git-info": {
+							"version": "2.8.8",
+							"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
+							"integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
+							"dev": true
+						},
+						"normalize-package-data": {
+							"version": "2.5.0",
+							"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+							"integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+							"dev": true,
+							"requires": {
+								"hosted-git-info": "^2.1.4",
+								"resolve": "^1.10.0",
+								"semver": "2 || 3 || 4 || 5",
+								"validate-npm-package-license": "^3.0.1"
+							}
+						},
+						"semver": {
+							"version": "5.7.1",
+							"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+							"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+							"dev": true
+						},
 						"type-fest": {
 							"version": "0.6.0",
 							"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
@@ -8497,29 +8580,36 @@
 						}
 					}
 				},
+				"resolve": {
+					"version": "1.19.0",
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
+					"integrity": "sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==",
+					"dev": true,
+					"requires": {
+						"is-core-module": "^2.1.0",
+						"path-parse": "^1.0.6"
+					}
+				},
+				"semver": {
+					"version": "7.3.4",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
+					"integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+					"dev": true,
+					"requires": {
+						"lru-cache": "^6.0.0"
+					}
+				},
 				"type-fest": {
-					"version": "0.13.1",
-					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
-					"integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
+					"version": "0.18.1",
+					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.18.1.tgz",
+					"integrity": "sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw==",
 					"dev": true
 				},
 				"yargs-parser": {
-					"version": "18.1.3",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
-					"integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
-					"dev": true,
-					"requires": {
-						"camelcase": "^5.0.0",
-						"decamelize": "^1.2.0"
-					},
-					"dependencies": {
-						"camelcase": {
-							"version": "5.3.1",
-							"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-							"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-							"dev": true
-						}
-					}
+					"version": "20.2.4",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
+					"integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==",
+					"dev": true
 				}
 			}
 		},
@@ -8602,14 +8692,6 @@
 				"arrify": "^1.0.1",
 				"is-plain-obj": "^1.1.0",
 				"kind-of": "^6.0.3"
-			},
-			"dependencies": {
-				"arrify": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-					"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
-					"dev": true
-				}
 			}
 		},
 		"mixin-deep": {
@@ -8805,15 +8887,15 @@
 			"dev": true
 		},
 		"normalize-url": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-5.1.0.tgz",
-			"integrity": "sha512-UxHuSWsSAmzSqN+DSjasaZWQ3QPtEisHdlr4y9MJ5zg0RcImv5fQt8QM0izJSCdsdmhJGK+ubcTpJXwVDmwSVQ==",
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-5.3.0.tgz",
+			"integrity": "sha512-9/nOVLYYe/dO/eJeQUNaGUF4m4Z5E7cb9oNTKabH+bNf19mqj60txTcveQxL0GlcWLXCxkOu2/LwL8oW0idIDA==",
 			"dev": true
 		},
 		"npm": {
-			"version": "6.14.7",
-			"resolved": "https://registry.npmjs.org/npm/-/npm-6.14.7.tgz",
-			"integrity": "sha512-swhsdpNpyXg4GbM6LpOQ6qaloQuIKizZ+Zh6JPXJQc59ka49100Js0WvZx594iaKSoFgkFq2s8uXFHS3/Xy2WQ==",
+			"version": "6.14.9",
+			"resolved": "https://registry.npmjs.org/npm/-/npm-6.14.9.tgz",
+			"integrity": "sha512-yHi1+i9LyAZF1gAmgyYtVk+HdABlLy94PMIDoK1TRKWvmFQAt5z3bodqVwKvzY0s6dLqQPVsRLiwhJfNtiHeCg==",
 			"dev": true,
 			"requires": {
 				"JSONStream": "^1.3.5",
@@ -8880,7 +8962,7 @@
 				"lodash.uniq": "~4.5.0",
 				"lodash.without": "~4.4.0",
 				"lru-cache": "^5.1.1",
-				"meant": "~1.0.1",
+				"meant": "^1.0.2",
 				"mississippi": "^3.0.0",
 				"mkdirp": "^0.5.5",
 				"move-concurrently": "^1.0.1",
@@ -8895,8 +8977,8 @@
 				"npm-packlist": "^1.4.8",
 				"npm-pick-manifest": "^3.0.2",
 				"npm-profile": "^4.0.4",
-				"npm-registry-fetch": "^4.0.5",
-				"npm-user-validate": "~1.0.0",
+				"npm-registry-fetch": "^4.0.7",
+				"npm-user-validate": "^1.0.1",
 				"npmlog": "~4.1.2",
 				"once": "~1.4.0",
 				"opener": "^1.5.1",
@@ -8943,8 +9025,7 @@
 			"dependencies": {
 				"JSONStream": {
 					"version": "1.3.5",
-					"resolved": false,
-					"integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"jsonparse": "^1.2.0",
@@ -8953,14 +9034,12 @@
 				},
 				"abbrev": {
 					"version": "1.1.1",
-					"resolved": false,
-					"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+					"bundled": true,
 					"dev": true
 				},
 				"agent-base": {
 					"version": "4.3.0",
-					"resolved": false,
-					"integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"es6-promisify": "^5.0.0"
@@ -8968,29 +9047,15 @@
 				},
 				"agentkeepalive": {
 					"version": "3.5.2",
-					"resolved": false,
-					"integrity": "sha512-e0L/HNe6qkQ7H19kTlRRqUibEAwDK5AFk6y3PtMsuut2VAH6+Q4xZml1tNDJD7kSAyqmbG/K08K5WEJYtUrSlQ==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"humanize-ms": "^1.2.1"
 					}
 				},
-				"ajv": {
-					"version": "5.5.2",
-					"resolved": false,
-					"integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
-					"dev": true,
-					"requires": {
-						"co": "^4.6.0",
-						"fast-deep-equal": "^1.0.0",
-						"fast-json-stable-stringify": "^2.0.0",
-						"json-schema-traverse": "^0.3.0"
-					}
-				},
 				"ansi-align": {
 					"version": "2.0.0",
-					"resolved": false,
-					"integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"string-width": "^2.0.0"
@@ -8998,14 +9063,12 @@
 				},
 				"ansi-regex": {
 					"version": "2.1.1",
-					"resolved": false,
-					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+					"bundled": true,
 					"dev": true
 				},
 				"ansi-styles": {
 					"version": "3.2.1",
-					"resolved": false,
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"color-convert": "^1.9.0"
@@ -9013,32 +9076,27 @@
 				},
 				"ansicolors": {
 					"version": "0.3.2",
-					"resolved": false,
-					"integrity": "sha1-ZlWX3oap/+Oqm/vmyuXG6kJrSXk=",
+					"bundled": true,
 					"dev": true
 				},
 				"ansistyles": {
 					"version": "0.1.3",
-					"resolved": false,
-					"integrity": "sha1-XeYEFb2gcbs3EnhUyGT0GyMlRTk=",
+					"bundled": true,
 					"dev": true
 				},
 				"aproba": {
 					"version": "2.0.0",
-					"resolved": false,
-					"integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==",
+					"bundled": true,
 					"dev": true
 				},
 				"archy": {
 					"version": "1.0.0",
-					"resolved": false,
-					"integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
+					"bundled": true,
 					"dev": true
 				},
 				"are-we-there-yet": {
 					"version": "1.1.4",
-					"resolved": false,
-					"integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"delegates": "^1.0.0",
@@ -9047,8 +9105,7 @@
 					"dependencies": {
 						"readable-stream": {
 							"version": "2.3.6",
-							"resolved": false,
-							"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+							"bundled": true,
 							"dev": true,
 							"requires": {
 								"core-util-is": "~1.0.0",
@@ -9062,8 +9119,7 @@
 						},
 						"string_decoder": {
 							"version": "1.1.1",
-							"resolved": false,
-							"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+							"bundled": true,
 							"dev": true,
 							"requires": {
 								"safe-buffer": "~5.1.0"
@@ -9073,14 +9129,12 @@
 				},
 				"asap": {
 					"version": "2.0.6",
-					"resolved": false,
-					"integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
+					"bundled": true,
 					"dev": true
 				},
 				"asn1": {
 					"version": "0.2.4",
-					"resolved": false,
-					"integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"safer-buffer": "~2.1.0"
@@ -9088,38 +9142,32 @@
 				},
 				"assert-plus": {
 					"version": "1.0.0",
-					"resolved": false,
-					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+					"bundled": true,
 					"dev": true
 				},
 				"asynckit": {
 					"version": "0.4.0",
-					"resolved": false,
-					"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+					"bundled": true,
 					"dev": true
 				},
 				"aws-sign2": {
 					"version": "0.7.0",
-					"resolved": false,
-					"integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+					"bundled": true,
 					"dev": true
 				},
 				"aws4": {
 					"version": "1.8.0",
-					"resolved": false,
-					"integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
+					"bundled": true,
 					"dev": true
 				},
 				"balanced-match": {
 					"version": "1.0.0",
-					"resolved": false,
-					"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+					"bundled": true,
 					"dev": true
 				},
 				"bcrypt-pbkdf": {
 					"version": "1.0.2",
-					"resolved": false,
-					"integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -9128,8 +9176,7 @@
 				},
 				"bin-links": {
 					"version": "1.1.8",
-					"resolved": "https://registry.npmjs.org/bin-links/-/bin-links-1.1.8.tgz",
-					"integrity": "sha512-KgmVfx+QqggqP9dA3iIc5pA4T1qEEEL+hOhOhNPaUm77OTrJoOXE/C05SJLNJe6m/2wUK7F1tDSou7n5TfCDzQ==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"bluebird": "^3.5.3",
@@ -9142,14 +9189,12 @@
 				},
 				"bluebird": {
 					"version": "3.5.5",
-					"resolved": false,
-					"integrity": "sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w==",
+					"bundled": true,
 					"dev": true
 				},
 				"boxen": {
 					"version": "1.3.0",
-					"resolved": false,
-					"integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"ansi-align": "^2.0.0",
@@ -9163,8 +9208,7 @@
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
-					"resolved": false,
-					"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
@@ -9173,32 +9217,27 @@
 				},
 				"buffer-from": {
 					"version": "1.0.0",
-					"resolved": false,
-					"integrity": "sha512-83apNb8KK0Se60UE1+4Ukbe3HbfELJ6UlI4ldtOGs7So4KD26orJM8hIY9lxdzP+UpItH1Yh/Y8GUvNFWFFRxA==",
+					"bundled": true,
 					"dev": true
 				},
 				"builtins": {
 					"version": "1.0.3",
-					"resolved": false,
-					"integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og=",
+					"bundled": true,
 					"dev": true
 				},
 				"byline": {
 					"version": "5.0.0",
-					"resolved": false,
-					"integrity": "sha1-dBxSFkaOrcRXsDQQEYrXfejB3bE=",
+					"bundled": true,
 					"dev": true
 				},
 				"byte-size": {
 					"version": "5.0.1",
-					"resolved": false,
-					"integrity": "sha512-/XuKeqWocKsYa/cBY1YbSJSWWqTi4cFgr9S6OyM7PBaPbr9zvNGwWP33vt0uqGhwDdN+y3yhbXVILEUpnwEWGw==",
+					"bundled": true,
 					"dev": true
 				},
 				"cacache": {
 					"version": "12.0.3",
-					"resolved": false,
-					"integrity": "sha512-kqdmfXEGFepesTuROHMs3MpFLWrPkSSpRqOw80RCflZXy/khxaArvFrQ7uJxSUduzAufc6G0g1VUCOZXxWavPw==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"bluebird": "^3.5.5",
@@ -9220,32 +9259,27 @@
 				},
 				"call-limit": {
 					"version": "1.1.1",
-					"resolved": false,
-					"integrity": "sha512-5twvci5b9eRBw2wCfPtN0GmlR2/gadZqyFpPhOK6CvMFoFgA+USnZ6Jpu1lhG9h85pQ3Ouil3PfXWRD4EUaRiQ==",
+					"bundled": true,
 					"dev": true
 				},
 				"camelcase": {
 					"version": "4.1.0",
-					"resolved": false,
-					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+					"bundled": true,
 					"dev": true
 				},
 				"capture-stack-trace": {
 					"version": "1.0.0",
-					"resolved": false,
-					"integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0=",
+					"bundled": true,
 					"dev": true
 				},
 				"caseless": {
 					"version": "0.12.0",
-					"resolved": false,
-					"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+					"bundled": true,
 					"dev": true
 				},
 				"chalk": {
 					"version": "2.4.1",
-					"resolved": false,
-					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"ansi-styles": "^3.2.1",
@@ -9255,20 +9289,17 @@
 				},
 				"chownr": {
 					"version": "1.1.4",
-					"resolved": false,
-					"integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+					"bundled": true,
 					"dev": true
 				},
 				"ci-info": {
 					"version": "2.0.0",
-					"resolved": false,
-					"integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
+					"bundled": true,
 					"dev": true
 				},
 				"cidr-regex": {
 					"version": "2.0.10",
-					"resolved": false,
-					"integrity": "sha512-sB3ogMQXWvreNPbJUZMRApxuRYd+KoIo4RGQ81VatjmMW6WJPo+IJZ2846FGItr9VzKo5w7DXzijPLGtSd0N3Q==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"ip-regex": "^2.1.0"
@@ -9276,14 +9307,12 @@
 				},
 				"cli-boxes": {
 					"version": "1.0.0",
-					"resolved": false,
-					"integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM=",
+					"bundled": true,
 					"dev": true
 				},
 				"cli-columns": {
 					"version": "3.1.2",
-					"resolved": false,
-					"integrity": "sha1-ZzLZcpee/CrkRKHwjgj6E5yWoY4=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"string-width": "^2.0.0",
@@ -9292,8 +9321,7 @@
 				},
 				"cli-table3": {
 					"version": "0.5.1",
-					"resolved": false,
-					"integrity": "sha512-7Qg2Jrep1S/+Q3EceiZtQcDPWxhAvBw+ERf1162v4sikJrvojMHFqXt8QIVha8UlH9rgU0BeWPytZ9/TzYqlUw==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"colors": "^1.1.2",
@@ -9303,8 +9331,7 @@
 				},
 				"cliui": {
 					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
-					"integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"string-width": "^3.1.0",
@@ -9314,20 +9341,17 @@
 					"dependencies": {
 						"ansi-regex": {
 							"version": "4.1.0",
-							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-							"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+							"bundled": true,
 							"dev": true
 						},
 						"is-fullwidth-code-point": {
 							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-							"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+							"bundled": true,
 							"dev": true
 						},
 						"string-width": {
 							"version": "3.1.0",
-							"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-							"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+							"bundled": true,
 							"dev": true,
 							"requires": {
 								"emoji-regex": "^7.0.1",
@@ -9337,8 +9361,7 @@
 						},
 						"strip-ansi": {
 							"version": "5.2.0",
-							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-							"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+							"bundled": true,
 							"dev": true,
 							"requires": {
 								"ansi-regex": "^4.1.0"
@@ -9348,36 +9371,26 @@
 				},
 				"clone": {
 					"version": "1.0.4",
-					"resolved": false,
-					"integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
+					"bundled": true,
 					"dev": true
 				},
 				"cmd-shim": {
 					"version": "3.0.3",
-					"resolved": false,
-					"integrity": "sha512-DtGg+0xiFhQIntSBRzL2fRQBnmtAVwXIDo4Qq46HPpObYquxMaZS4sb82U9nH91qJrlosC1wa9gwr0QyL/HypA==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.2",
 						"mkdirp": "~0.5.0"
 					}
 				},
-				"co": {
-					"version": "4.6.0",
-					"resolved": false,
-					"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
-					"dev": true
-				},
 				"code-point-at": {
 					"version": "1.1.0",
-					"resolved": false,
-					"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+					"bundled": true,
 					"dev": true
 				},
 				"color-convert": {
 					"version": "1.9.1",
-					"resolved": false,
-					"integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"color-name": "^1.1.1"
@@ -9385,21 +9398,18 @@
 				},
 				"color-name": {
 					"version": "1.1.3",
-					"resolved": false,
-					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+					"bundled": true,
 					"dev": true
 				},
 				"colors": {
 					"version": "1.3.3",
-					"resolved": false,
-					"integrity": "sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg==",
+					"bundled": true,
 					"dev": true,
 					"optional": true
 				},
 				"columnify": {
 					"version": "1.5.4",
-					"resolved": false,
-					"integrity": "sha1-Rzfd8ce2mop8NAVweC6UfuyOeLs=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"strip-ansi": "^3.0.0",
@@ -9408,8 +9418,7 @@
 				},
 				"combined-stream": {
 					"version": "1.0.6",
-					"resolved": false,
-					"integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"delayed-stream": "~1.0.0"
@@ -9417,14 +9426,12 @@
 				},
 				"concat-map": {
 					"version": "0.0.1",
-					"resolved": false,
-					"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+					"bundled": true,
 					"dev": true
 				},
 				"concat-stream": {
 					"version": "1.6.2",
-					"resolved": false,
-					"integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"buffer-from": "^1.0.0",
@@ -9435,8 +9442,7 @@
 					"dependencies": {
 						"readable-stream": {
 							"version": "2.3.6",
-							"resolved": false,
-							"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+							"bundled": true,
 							"dev": true,
 							"requires": {
 								"core-util-is": "~1.0.0",
@@ -9450,8 +9456,7 @@
 						},
 						"string_decoder": {
 							"version": "1.1.1",
-							"resolved": false,
-							"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+							"bundled": true,
 							"dev": true,
 							"requires": {
 								"safe-buffer": "~5.1.0"
@@ -9461,8 +9466,7 @@
 				},
 				"config-chain": {
 					"version": "1.1.12",
-					"resolved": false,
-					"integrity": "sha512-a1eOIcu8+7lUInge4Rpf/n4Krkf3Dd9lqhljRzII1/Zno/kRtUWnznPO3jOKBmTEktkt3fkxisUcivoj0ebzoA==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"ini": "^1.3.4",
@@ -9470,12 +9474,11 @@
 					}
 				},
 				"configstore": {
-					"version": "3.1.2",
-					"resolved": false,
-					"integrity": "sha512-vtv5HtGjcYUgFrXc6Kx747B83MRRVS5R1VTEQoXvuP+kMI+if6uywV0nDGoiydJRy4yk7h9od5Og0kxx4zUXmw==",
+					"version": "3.1.5",
+					"bundled": true,
 					"dev": true,
 					"requires": {
-						"dot-prop": "^4.1.0",
+						"dot-prop": "^4.2.1",
 						"graceful-fs": "^4.1.2",
 						"make-dir": "^1.0.0",
 						"unique-string": "^1.0.0",
@@ -9485,14 +9488,12 @@
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
-					"resolved": false,
-					"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+					"bundled": true,
 					"dev": true
 				},
 				"copy-concurrently": {
 					"version": "1.0.5",
-					"resolved": false,
-					"integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"aproba": "^1.1.1",
@@ -9505,28 +9506,24 @@
 					"dependencies": {
 						"aproba": {
 							"version": "1.2.0",
-							"resolved": false,
-							"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+							"bundled": true,
 							"dev": true
 						},
 						"iferr": {
 							"version": "0.1.5",
-							"resolved": false,
-							"integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
+							"bundled": true,
 							"dev": true
 						}
 					}
 				},
 				"core-util-is": {
 					"version": "1.0.2",
-					"resolved": false,
-					"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+					"bundled": true,
 					"dev": true
 				},
 				"create-error-class": {
 					"version": "3.0.2",
-					"resolved": false,
-					"integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"capture-stack-trace": "^1.0.0"
@@ -9534,8 +9531,7 @@
 				},
 				"cross-spawn": {
 					"version": "5.1.0",
-					"resolved": false,
-					"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"lru-cache": "^4.0.1",
@@ -9545,8 +9541,7 @@
 					"dependencies": {
 						"lru-cache": {
 							"version": "4.1.5",
-							"resolved": false,
-							"integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+							"bundled": true,
 							"dev": true,
 							"requires": {
 								"pseudomap": "^1.0.2",
@@ -9555,28 +9550,24 @@
 						},
 						"yallist": {
 							"version": "2.1.2",
-							"resolved": false,
-							"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+							"bundled": true,
 							"dev": true
 						}
 					}
 				},
 				"crypto-random-string": {
 					"version": "1.0.0",
-					"resolved": false,
-					"integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
+					"bundled": true,
 					"dev": true
 				},
 				"cyclist": {
 					"version": "0.2.2",
-					"resolved": false,
-					"integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA=",
+					"bundled": true,
 					"dev": true
 				},
 				"dashdash": {
 					"version": "1.14.1",
-					"resolved": false,
-					"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"assert-plus": "^1.0.0"
@@ -9584,8 +9575,7 @@
 				},
 				"debug": {
 					"version": "3.1.0",
-					"resolved": false,
-					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
@@ -9593,40 +9583,34 @@
 					"dependencies": {
 						"ms": {
 							"version": "2.0.0",
-							"resolved": false,
-							"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+							"bundled": true,
 							"dev": true
 						}
 					}
 				},
 				"debuglog": {
 					"version": "1.0.1",
-					"resolved": false,
-					"integrity": "sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=",
+					"bundled": true,
 					"dev": true
 				},
 				"decamelize": {
 					"version": "1.2.0",
-					"resolved": false,
-					"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+					"bundled": true,
 					"dev": true
 				},
 				"decode-uri-component": {
 					"version": "0.2.0",
-					"resolved": false,
-					"integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+					"bundled": true,
 					"dev": true
 				},
 				"deep-extend": {
 					"version": "0.6.0",
-					"resolved": false,
-					"integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+					"bundled": true,
 					"dev": true
 				},
 				"defaults": {
 					"version": "1.0.3",
-					"resolved": false,
-					"integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"clone": "^1.0.2"
@@ -9634,8 +9618,7 @@
 				},
 				"define-properties": {
 					"version": "1.1.3",
-					"resolved": false,
-					"integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"object-keys": "^1.0.12"
@@ -9643,32 +9626,27 @@
 				},
 				"delayed-stream": {
 					"version": "1.0.0",
-					"resolved": false,
-					"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+					"bundled": true,
 					"dev": true
 				},
 				"delegates": {
 					"version": "1.0.0",
-					"resolved": false,
-					"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+					"bundled": true,
 					"dev": true
 				},
 				"detect-indent": {
 					"version": "5.0.0",
-					"resolved": false,
-					"integrity": "sha1-OHHMCmoALow+Wzz38zYmRnXwa50=",
+					"bundled": true,
 					"dev": true
 				},
 				"detect-newline": {
 					"version": "2.1.0",
-					"resolved": false,
-					"integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=",
+					"bundled": true,
 					"dev": true
 				},
 				"dezalgo": {
 					"version": "1.0.3",
-					"resolved": false,
-					"integrity": "sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"asap": "^2.0.0",
@@ -9676,8 +9654,8 @@
 					}
 				},
 				"dot-prop": {
-					"version": "4.2.0",
-					"resolved": "",
+					"version": "4.2.1",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"is-obj": "^1.0.0"
@@ -9685,20 +9663,17 @@
 				},
 				"dotenv": {
 					"version": "5.0.1",
-					"resolved": false,
-					"integrity": "sha512-4As8uPrjfwb7VXC+WnLCbXK7y+Ueb2B3zgNCePYfhxS1PYeaO1YTeplffTEcbfLhvFNGLAz90VvJs9yomG7bow==",
+					"bundled": true,
 					"dev": true
 				},
 				"duplexer3": {
 					"version": "0.1.4",
-					"resolved": false,
-					"integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
+					"bundled": true,
 					"dev": true
 				},
 				"duplexify": {
 					"version": "3.6.0",
-					"resolved": false,
-					"integrity": "sha512-fO3Di4tBKJpYTFHAxTU00BcfWMY9w24r/x21a6rZRbsD/ToUgGxsMbiGRmB7uVAXeGKXD9MwiLZa5E97EVgIRQ==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"end-of-stream": "^1.0.0",
@@ -9709,8 +9684,7 @@
 					"dependencies": {
 						"readable-stream": {
 							"version": "2.3.6",
-							"resolved": false,
-							"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+							"bundled": true,
 							"dev": true,
 							"requires": {
 								"core-util-is": "~1.0.0",
@@ -9724,8 +9698,7 @@
 						},
 						"string_decoder": {
 							"version": "1.1.1",
-							"resolved": false,
-							"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+							"bundled": true,
 							"dev": true,
 							"requires": {
 								"safe-buffer": "~5.1.0"
@@ -9735,8 +9708,7 @@
 				},
 				"ecc-jsbn": {
 					"version": "0.1.2",
-					"resolved": false,
-					"integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -9746,20 +9718,17 @@
 				},
 				"editor": {
 					"version": "1.0.0",
-					"resolved": false,
-					"integrity": "sha1-YMf4e9YrzGqJT6jM1q+3gjok90I=",
+					"bundled": true,
 					"dev": true
 				},
 				"emoji-regex": {
 					"version": "7.0.3",
-					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-					"integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+					"bundled": true,
 					"dev": true
 				},
 				"encoding": {
 					"version": "0.1.12",
-					"resolved": false,
-					"integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"iconv-lite": "~0.4.13"
@@ -9767,8 +9736,7 @@
 				},
 				"end-of-stream": {
 					"version": "1.4.1",
-					"resolved": false,
-					"integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"once": "^1.4.0"
@@ -9776,20 +9744,17 @@
 				},
 				"env-paths": {
 					"version": "2.2.0",
-					"resolved": false,
-					"integrity": "sha512-6u0VYSCo/OW6IoD5WCLLy9JUGARbamfSavcNXry/eu8aHVFei6CD3Sw+VGX5alea1i9pgPHW0mbu6Xj0uBh7gA==",
+					"bundled": true,
 					"dev": true
 				},
 				"err-code": {
 					"version": "1.1.2",
-					"resolved": false,
-					"integrity": "sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA=",
+					"bundled": true,
 					"dev": true
 				},
 				"errno": {
 					"version": "0.1.7",
-					"resolved": false,
-					"integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"prr": "~1.0.1"
@@ -9797,8 +9762,7 @@
 				},
 				"es-abstract": {
 					"version": "1.12.0",
-					"resolved": false,
-					"integrity": "sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"es-to-primitive": "^1.1.1",
@@ -9810,8 +9774,7 @@
 				},
 				"es-to-primitive": {
 					"version": "1.2.0",
-					"resolved": false,
-					"integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"is-callable": "^1.1.4",
@@ -9821,14 +9784,12 @@
 				},
 				"es6-promise": {
 					"version": "4.2.8",
-					"resolved": false,
-					"integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
+					"bundled": true,
 					"dev": true
 				},
 				"es6-promisify": {
 					"version": "5.0.0",
-					"resolved": false,
-					"integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"es6-promise": "^4.0.3"
@@ -9836,14 +9797,12 @@
 				},
 				"escape-string-regexp": {
 					"version": "1.0.5",
-					"resolved": false,
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+					"bundled": true,
 					"dev": true
 				},
 				"execa": {
 					"version": "0.7.0",
-					"resolved": false,
-					"integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"cross-spawn": "^5.0.1",
@@ -9857,52 +9816,39 @@
 					"dependencies": {
 						"get-stream": {
 							"version": "3.0.0",
-							"resolved": false,
-							"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+							"bundled": true,
 							"dev": true
 						}
 					}
 				},
 				"extend": {
 					"version": "3.0.2",
-					"resolved": false,
-					"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+					"bundled": true,
 					"dev": true
 				},
 				"extsprintf": {
 					"version": "1.3.0",
-					"resolved": false,
-					"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
-					"dev": true
-				},
-				"fast-deep-equal": {
-					"version": "1.1.0",
-					"resolved": false,
-					"integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
+					"bundled": true,
 					"dev": true
 				},
 				"fast-json-stable-stringify": {
 					"version": "2.0.0",
-					"resolved": false,
-					"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+					"bundled": true,
 					"dev": true
 				},
 				"figgy-pudding": {
 					"version": "3.5.1",
-					"resolved": false,
-					"integrity": "sha512-vNKxJHTEKNThjfrdJwHc7brvM6eVevuO5nTj6ez8ZQ1qbXTvGthucRF7S4vf2cr71QVnT70V34v0S1DyQsti0w==",
+					"bundled": true,
 					"dev": true
 				},
 				"find-npm-prefix": {
 					"version": "1.0.2",
-					"resolved": false,
-					"integrity": "sha512-KEftzJ+H90x6pcKtdXZEPsQse8/y/UnvzRKrOSQFprnrGaFuJ62fVkP34Iu2IYuMvyauCyoLTNkJZgrrGA2wkA==",
+					"bundled": true,
 					"dev": true
 				},
 				"flush-write-stream": {
 					"version": "1.0.3",
-					"resolved": false,
-					"integrity": "sha512-calZMC10u0FMUqoiunI2AiGIIUtUIvifNwkHhNupZH4cbNnW1Itkoh/Nf5HFYmDrwWPjrUxpkZT0KhuCq0jmGw==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"inherits": "^2.0.1",
@@ -9911,8 +9857,7 @@
 					"dependencies": {
 						"readable-stream": {
 							"version": "2.3.6",
-							"resolved": false,
-							"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+							"bundled": true,
 							"dev": true,
 							"requires": {
 								"core-util-is": "~1.0.0",
@@ -9926,8 +9871,7 @@
 						},
 						"string_decoder": {
 							"version": "1.1.1",
-							"resolved": false,
-							"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+							"bundled": true,
 							"dev": true,
 							"requires": {
 								"safe-buffer": "~5.1.0"
@@ -9937,14 +9881,12 @@
 				},
 				"forever-agent": {
 					"version": "0.6.1",
-					"resolved": false,
-					"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+					"bundled": true,
 					"dev": true
 				},
 				"form-data": {
 					"version": "2.3.2",
-					"resolved": false,
-					"integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"asynckit": "^0.4.0",
@@ -9954,8 +9896,7 @@
 				},
 				"from2": {
 					"version": "2.3.0",
-					"resolved": false,
-					"integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"inherits": "^2.0.1",
@@ -9964,8 +9905,7 @@
 					"dependencies": {
 						"readable-stream": {
 							"version": "2.3.6",
-							"resolved": false,
-							"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+							"bundled": true,
 							"dev": true,
 							"requires": {
 								"core-util-is": "~1.0.0",
@@ -9979,8 +9919,7 @@
 						},
 						"string_decoder": {
 							"version": "1.1.1",
-							"resolved": false,
-							"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+							"bundled": true,
 							"dev": true,
 							"requires": {
 								"safe-buffer": "~5.1.0"
@@ -9990,8 +9929,7 @@
 				},
 				"fs-minipass": {
 					"version": "1.2.7",
-					"resolved": false,
-					"integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"minipass": "^2.6.0"
@@ -9999,8 +9937,7 @@
 					"dependencies": {
 						"minipass": {
 							"version": "2.9.0",
-							"resolved": false,
-							"integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
+							"bundled": true,
 							"dev": true,
 							"requires": {
 								"safe-buffer": "^5.1.2",
@@ -10011,8 +9948,7 @@
 				},
 				"fs-vacuum": {
 					"version": "1.2.10",
-					"resolved": false,
-					"integrity": "sha1-t2Kb7AekAxolSP35n17PHMizHjY=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.2",
@@ -10022,8 +9958,7 @@
 				},
 				"fs-write-stream-atomic": {
 					"version": "1.0.10",
-					"resolved": false,
-					"integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.2",
@@ -10034,14 +9969,12 @@
 					"dependencies": {
 						"iferr": {
 							"version": "0.1.5",
-							"resolved": false,
-							"integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
+							"bundled": true,
 							"dev": true
 						},
 						"readable-stream": {
 							"version": "2.3.6",
-							"resolved": false,
-							"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+							"bundled": true,
 							"dev": true,
 							"requires": {
 								"core-util-is": "~1.0.0",
@@ -10055,8 +9988,7 @@
 						},
 						"string_decoder": {
 							"version": "1.1.1",
-							"resolved": false,
-							"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+							"bundled": true,
 							"dev": true,
 							"requires": {
 								"safe-buffer": "~5.1.0"
@@ -10066,20 +9998,17 @@
 				},
 				"fs.realpath": {
 					"version": "1.0.0",
-					"resolved": false,
-					"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+					"bundled": true,
 					"dev": true
 				},
 				"function-bind": {
 					"version": "1.1.1",
-					"resolved": false,
-					"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+					"bundled": true,
 					"dev": true
 				},
 				"gauge": {
 					"version": "2.7.4",
-					"resolved": false,
-					"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"aproba": "^1.0.3",
@@ -10094,14 +10023,12 @@
 					"dependencies": {
 						"aproba": {
 							"version": "1.2.0",
-							"resolved": false,
-							"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+							"bundled": true,
 							"dev": true
 						},
 						"string-width": {
 							"version": "1.0.2",
-							"resolved": false,
-							"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+							"bundled": true,
 							"dev": true,
 							"requires": {
 								"code-point-at": "^1.0.0",
@@ -10113,14 +10040,12 @@
 				},
 				"genfun": {
 					"version": "5.0.0",
-					"resolved": false,
-					"integrity": "sha512-KGDOARWVga7+rnB3z9Sd2Letx515owfk0hSxHGuqjANb1M+x2bGZGqHLiozPsYMdM2OubeMni/Hpwmjq6qIUhA==",
+					"bundled": true,
 					"dev": true
 				},
 				"gentle-fs": {
 					"version": "2.3.1",
-					"resolved": "https://registry.npmjs.org/gentle-fs/-/gentle-fs-2.3.1.tgz",
-					"integrity": "sha512-OlwBBwqCFPcjm33rF2BjW+Pr6/ll2741l+xooiwTCeaX2CA1ZuclavyMBe0/KlR21/XGsgY6hzEQZ15BdNa13Q==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"aproba": "^1.1.2",
@@ -10138,28 +10063,24 @@
 					"dependencies": {
 						"aproba": {
 							"version": "1.2.0",
-							"resolved": false,
-							"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+							"bundled": true,
 							"dev": true
 						},
 						"iferr": {
 							"version": "0.1.5",
-							"resolved": false,
-							"integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
+							"bundled": true,
 							"dev": true
 						}
 					}
 				},
 				"get-caller-file": {
 					"version": "2.0.5",
-					"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-					"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+					"bundled": true,
 					"dev": true
 				},
 				"get-stream": {
 					"version": "4.1.0",
-					"resolved": false,
-					"integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"pump": "^3.0.0"
@@ -10167,8 +10088,7 @@
 				},
 				"getpass": {
 					"version": "0.1.7",
-					"resolved": false,
-					"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"assert-plus": "^1.0.0"
@@ -10176,8 +10096,7 @@
 				},
 				"glob": {
 					"version": "7.1.6",
-					"resolved": false,
-					"integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"fs.realpath": "^1.0.0",
@@ -10190,8 +10109,7 @@
 				},
 				"global-dirs": {
 					"version": "0.1.1",
-					"resolved": false,
-					"integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"ini": "^1.3.4"
@@ -10199,8 +10117,7 @@
 				},
 				"got": {
 					"version": "6.7.1",
-					"resolved": false,
-					"integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"create-error-class": "^3.0.0",
@@ -10218,38 +10135,56 @@
 					"dependencies": {
 						"get-stream": {
 							"version": "3.0.0",
-							"resolved": false,
-							"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+							"bundled": true,
 							"dev": true
 						}
 					}
 				},
 				"graceful-fs": {
 					"version": "4.2.4",
-					"resolved": false,
-					"integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+					"bundled": true,
 					"dev": true
 				},
 				"har-schema": {
 					"version": "2.0.0",
-					"resolved": false,
-					"integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+					"bundled": true,
 					"dev": true
 				},
 				"har-validator": {
-					"version": "5.1.0",
-					"resolved": false,
-					"integrity": "sha512-+qnmNjI4OfH2ipQ9VQOw23bBd/ibtfbVdK2fYbY4acTDqKTW/YDp9McimZdDbG8iV9fZizUqQMD5xvriB146TA==",
+					"version": "5.1.5",
+					"bundled": true,
 					"dev": true,
 					"requires": {
-						"ajv": "^5.3.0",
+						"ajv": "^6.12.3",
 						"har-schema": "^2.0.0"
+					},
+					"dependencies": {
+						"ajv": {
+							"version": "6.12.6",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"fast-deep-equal": "^3.1.1",
+								"fast-json-stable-stringify": "^2.0.0",
+								"json-schema-traverse": "^0.4.1",
+								"uri-js": "^4.2.2"
+							}
+						},
+						"fast-deep-equal": {
+							"version": "3.1.3",
+							"bundled": true,
+							"dev": true
+						},
+						"json-schema-traverse": {
+							"version": "0.4.1",
+							"bundled": true,
+							"dev": true
+						}
 					}
 				},
 				"has": {
 					"version": "1.0.3",
-					"resolved": false,
-					"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"function-bind": "^1.1.1"
@@ -10257,38 +10192,32 @@
 				},
 				"has-flag": {
 					"version": "3.0.0",
-					"resolved": false,
-					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+					"bundled": true,
 					"dev": true
 				},
 				"has-symbols": {
 					"version": "1.0.0",
-					"resolved": false,
-					"integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
+					"bundled": true,
 					"dev": true
 				},
 				"has-unicode": {
 					"version": "2.0.1",
-					"resolved": false,
-					"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+					"bundled": true,
 					"dev": true
 				},
 				"hosted-git-info": {
 					"version": "2.8.8",
-					"resolved": false,
-					"integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
+					"bundled": true,
 					"dev": true
 				},
 				"http-cache-semantics": {
 					"version": "3.8.1",
-					"resolved": false,
-					"integrity": "sha512-5ai2iksyV8ZXmnZhHH4rWPoxxistEexSi5936zIQ1bnNTW5VnA85B6P/VpXiRM017IgRvb2kKo1a//y+0wSp3w==",
+					"bundled": true,
 					"dev": true
 				},
 				"http-proxy-agent": {
 					"version": "2.1.0",
-					"resolved": false,
-					"integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"agent-base": "4",
@@ -10297,8 +10226,7 @@
 				},
 				"http-signature": {
 					"version": "1.2.0",
-					"resolved": false,
-					"integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"assert-plus": "^1.0.0",
@@ -10308,8 +10236,7 @@
 				},
 				"https-proxy-agent": {
 					"version": "2.2.4",
-					"resolved": false,
-					"integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"agent-base": "^4.3.0",
@@ -10318,8 +10245,7 @@
 				},
 				"humanize-ms": {
 					"version": "1.2.1",
-					"resolved": false,
-					"integrity": "sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"ms": "^2.0.0"
@@ -10327,8 +10253,7 @@
 				},
 				"iconv-lite": {
 					"version": "0.4.23",
-					"resolved": false,
-					"integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"safer-buffer": ">= 2.1.2 < 3"
@@ -10336,14 +10261,12 @@
 				},
 				"iferr": {
 					"version": "1.0.2",
-					"resolved": false,
-					"integrity": "sha512-9AfeLfji44r5TKInjhz3W9DyZI1zR1JAf2hVBMGhddAKPqBsupb89jGfbCTHIGZd6fGZl9WlHdn4AObygyMKwg==",
+					"bundled": true,
 					"dev": true
 				},
 				"ignore-walk": {
 					"version": "3.0.3",
-					"resolved": false,
-					"integrity": "sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"minimatch": "^3.0.4"
@@ -10351,26 +10274,22 @@
 				},
 				"import-lazy": {
 					"version": "2.1.0",
-					"resolved": false,
-					"integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=",
+					"bundled": true,
 					"dev": true
 				},
 				"imurmurhash": {
 					"version": "0.1.4",
-					"resolved": false,
-					"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+					"bundled": true,
 					"dev": true
 				},
 				"infer-owner": {
 					"version": "1.0.4",
-					"resolved": false,
-					"integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==",
+					"bundled": true,
 					"dev": true
 				},
 				"inflight": {
 					"version": "1.0.6",
-					"resolved": false,
-					"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"once": "^1.3.0",
@@ -10379,20 +10298,17 @@
 				},
 				"inherits": {
 					"version": "2.0.4",
-					"resolved": false,
-					"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+					"bundled": true,
 					"dev": true
 				},
 				"ini": {
 					"version": "1.3.5",
-					"resolved": false,
-					"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+					"bundled": true,
 					"dev": true
 				},
 				"init-package-json": {
 					"version": "1.10.3",
-					"resolved": false,
-					"integrity": "sha512-zKSiXKhQveNteyhcj1CoOP8tqp1QuxPIPBl8Bid99DGLFqA1p87M6lNgfjJHSBoWJJlidGOv5rWjyYKEB3g2Jw==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"glob": "^7.1.1",
@@ -10407,26 +10323,22 @@
 				},
 				"ip": {
 					"version": "1.1.5",
-					"resolved": false,
-					"integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
+					"bundled": true,
 					"dev": true
 				},
 				"ip-regex": {
 					"version": "2.1.0",
-					"resolved": false,
-					"integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=",
+					"bundled": true,
 					"dev": true
 				},
 				"is-callable": {
 					"version": "1.1.4",
-					"resolved": false,
-					"integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
+					"bundled": true,
 					"dev": true
 				},
 				"is-ci": {
 					"version": "1.2.1",
-					"resolved": false,
-					"integrity": "sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"ci-info": "^1.5.0"
@@ -10434,16 +10346,14 @@
 					"dependencies": {
 						"ci-info": {
 							"version": "1.6.0",
-							"resolved": false,
-							"integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A==",
+							"bundled": true,
 							"dev": true
 						}
 					}
 				},
 				"is-cidr": {
 					"version": "3.0.0",
-					"resolved": false,
-					"integrity": "sha512-8Xnnbjsb0x462VoYiGlhEi+drY8SFwrHiSYuzc/CEwco55vkehTaxAyIjEdpi3EMvLPPJAJi9FlzP+h+03gp0Q==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"cidr-regex": "^2.0.10"
@@ -10451,14 +10361,12 @@
 				},
 				"is-date-object": {
 					"version": "1.0.1",
-					"resolved": false,
-					"integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+					"bundled": true,
 					"dev": true
 				},
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
-					"resolved": false,
-					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
@@ -10466,8 +10374,7 @@
 				},
 				"is-installed-globally": {
 					"version": "0.1.0",
-					"resolved": false,
-					"integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"global-dirs": "^0.1.0",
@@ -10476,20 +10383,17 @@
 				},
 				"is-npm": {
 					"version": "1.0.0",
-					"resolved": false,
-					"integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ=",
+					"bundled": true,
 					"dev": true
 				},
 				"is-obj": {
 					"version": "1.0.1",
-					"resolved": false,
-					"integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
+					"bundled": true,
 					"dev": true
 				},
 				"is-path-inside": {
 					"version": "1.0.1",
-					"resolved": false,
-					"integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"path-is-inside": "^1.0.1"
@@ -10497,14 +10401,12 @@
 				},
 				"is-redirect": {
 					"version": "1.0.0",
-					"resolved": false,
-					"integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
+					"bundled": true,
 					"dev": true
 				},
 				"is-regex": {
 					"version": "1.0.4",
-					"resolved": false,
-					"integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"has": "^1.0.1"
@@ -10512,20 +10414,17 @@
 				},
 				"is-retry-allowed": {
 					"version": "1.2.0",
-					"resolved": false,
-					"integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg==",
+					"bundled": true,
 					"dev": true
 				},
 				"is-stream": {
 					"version": "1.1.0",
-					"resolved": false,
-					"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+					"bundled": true,
 					"dev": true
 				},
 				"is-symbol": {
 					"version": "1.0.2",
-					"resolved": false,
-					"integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"has-symbols": "^1.0.0"
@@ -10533,69 +10432,53 @@
 				},
 				"is-typedarray": {
 					"version": "1.0.0",
-					"resolved": false,
-					"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+					"bundled": true,
 					"dev": true
 				},
 				"isarray": {
 					"version": "1.0.0",
-					"resolved": false,
-					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+					"bundled": true,
 					"dev": true
 				},
 				"isexe": {
 					"version": "2.0.0",
-					"resolved": false,
-					"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+					"bundled": true,
 					"dev": true
 				},
 				"isstream": {
 					"version": "0.1.2",
-					"resolved": false,
-					"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+					"bundled": true,
 					"dev": true
 				},
 				"jsbn": {
 					"version": "0.1.1",
-					"resolved": false,
-					"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+					"bundled": true,
 					"dev": true,
 					"optional": true
 				},
 				"json-parse-better-errors": {
 					"version": "1.0.2",
-					"resolved": false,
-					"integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+					"bundled": true,
 					"dev": true
 				},
 				"json-schema": {
 					"version": "0.2.3",
-					"resolved": false,
-					"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
-					"dev": true
-				},
-				"json-schema-traverse": {
-					"version": "0.3.1",
-					"resolved": false,
-					"integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+					"bundled": true,
 					"dev": true
 				},
 				"json-stringify-safe": {
 					"version": "5.0.1",
-					"resolved": false,
-					"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+					"bundled": true,
 					"dev": true
 				},
 				"jsonparse": {
 					"version": "1.3.1",
-					"resolved": false,
-					"integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
+					"bundled": true,
 					"dev": true
 				},
 				"jsprim": {
 					"version": "1.4.1",
-					"resolved": false,
-					"integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"assert-plus": "1.0.0",
@@ -10606,8 +10489,7 @@
 				},
 				"latest-version": {
 					"version": "3.1.0",
-					"resolved": false,
-					"integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"package-json": "^4.0.0"
@@ -10615,14 +10497,12 @@
 				},
 				"lazy-property": {
 					"version": "1.0.0",
-					"resolved": false,
-					"integrity": "sha1-hN3Es3Bnm6i9TNz6TAa0PVcREUc=",
+					"bundled": true,
 					"dev": true
 				},
 				"libcipm": {
 					"version": "4.0.8",
-					"resolved": "https://registry.npmjs.org/libcipm/-/libcipm-4.0.8.tgz",
-					"integrity": "sha512-IN3hh2yDJQtZZ5paSV4fbvJg4aHxCCg5tcZID/dSVlTuUiWktsgaldVljJv6Z5OUlYspx6xQkbR0efNodnIrOA==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"bin-links": "^1.1.2",
@@ -10644,8 +10524,7 @@
 				},
 				"libnpm": {
 					"version": "3.0.1",
-					"resolved": false,
-					"integrity": "sha512-d7jU5ZcMiTfBqTUJVZ3xid44fE5ERBm9vBnmhp2ECD2Ls+FNXWxHSkO7gtvrnbLO78gwPdNPz1HpsF3W4rjkBQ==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"bin-links": "^1.1.2",
@@ -10672,8 +10551,7 @@
 				},
 				"libnpmaccess": {
 					"version": "3.0.2",
-					"resolved": false,
-					"integrity": "sha512-01512AK7MqByrI2mfC7h5j8N9V4I7MHJuk9buo8Gv+5QgThpOgpjB7sQBDDkeZqRteFb1QM/6YNdHfG7cDvfAQ==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"aproba": "^2.0.0",
@@ -10684,8 +10562,7 @@
 				},
 				"libnpmconfig": {
 					"version": "1.2.1",
-					"resolved": false,
-					"integrity": "sha512-9esX8rTQAHqarx6qeZqmGQKBNZR5OIbl/Ayr0qQDy3oXja2iFVQQI81R6GZ2a02bSNZ9p3YOGX1O6HHCb1X7kA==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"figgy-pudding": "^3.5.1",
@@ -10695,8 +10572,7 @@
 					"dependencies": {
 						"find-up": {
 							"version": "3.0.0",
-							"resolved": false,
-							"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+							"bundled": true,
 							"dev": true,
 							"requires": {
 								"locate-path": "^3.0.0"
@@ -10704,8 +10580,7 @@
 						},
 						"locate-path": {
 							"version": "3.0.0",
-							"resolved": false,
-							"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+							"bundled": true,
 							"dev": true,
 							"requires": {
 								"p-locate": "^3.0.0",
@@ -10714,8 +10589,7 @@
 						},
 						"p-limit": {
 							"version": "2.2.0",
-							"resolved": false,
-							"integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+							"bundled": true,
 							"dev": true,
 							"requires": {
 								"p-try": "^2.0.0"
@@ -10723,8 +10597,7 @@
 						},
 						"p-locate": {
 							"version": "3.0.0",
-							"resolved": false,
-							"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+							"bundled": true,
 							"dev": true,
 							"requires": {
 								"p-limit": "^2.0.0"
@@ -10732,16 +10605,14 @@
 						},
 						"p-try": {
 							"version": "2.2.0",
-							"resolved": false,
-							"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+							"bundled": true,
 							"dev": true
 						}
 					}
 				},
 				"libnpmhook": {
 					"version": "5.0.3",
-					"resolved": false,
-					"integrity": "sha512-UdNLMuefVZra/wbnBXECZPefHMGsVDTq5zaM/LgKNE9Keyl5YXQTnGAzEo+nFOpdRqTWI9LYi4ApqF9uVCCtuA==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"aproba": "^2.0.0",
@@ -10752,8 +10623,7 @@
 				},
 				"libnpmorg": {
 					"version": "1.0.1",
-					"resolved": false,
-					"integrity": "sha512-0sRUXLh+PLBgZmARvthhYXQAWn0fOsa6T5l3JSe2n9vKG/lCVK4nuG7pDsa7uMq+uTt2epdPK+a2g6btcY11Ww==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"aproba": "^2.0.0",
@@ -10764,8 +10634,7 @@
 				},
 				"libnpmpublish": {
 					"version": "1.1.2",
-					"resolved": false,
-					"integrity": "sha512-2yIwaXrhTTcF7bkJKIKmaCV9wZOALf/gsTDxVSu/Gu/6wiG3fA8ce8YKstiWKTxSFNC0R7isPUb6tXTVFZHt2g==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"aproba": "^2.0.0",
@@ -10781,8 +10650,7 @@
 				},
 				"libnpmsearch": {
 					"version": "2.0.2",
-					"resolved": false,
-					"integrity": "sha512-VTBbV55Q6fRzTdzziYCr64+f8AopQ1YZ+BdPOv16UegIEaE8C0Kch01wo4s3kRTFV64P121WZJwgmBwrq68zYg==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"figgy-pudding": "^3.5.1",
@@ -10792,8 +10660,7 @@
 				},
 				"libnpmteam": {
 					"version": "1.0.2",
-					"resolved": false,
-					"integrity": "sha512-p420vM28Us04NAcg1rzgGW63LMM6rwe+6rtZpfDxCcXxM0zUTLl7nPFEnRF3JfFBF5skF/yuZDUthTsHgde8QA==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"aproba": "^2.0.0",
@@ -10804,8 +10671,7 @@
 				},
 				"libnpx": {
 					"version": "10.2.4",
-					"resolved": "https://registry.npmjs.org/libnpx/-/libnpx-10.2.4.tgz",
-					"integrity": "sha512-BPc0D1cOjBeS8VIBKUu5F80s6njm0wbVt7CsGMrIcJ+SI7pi7V0uVPGpEMH9H5L8csOcclTxAXFE2VAsJXUhfA==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"dotenv": "^5.0.1",
@@ -10820,8 +10686,7 @@
 				},
 				"lock-verify": {
 					"version": "2.1.0",
-					"resolved": false,
-					"integrity": "sha512-vcLpxnGvrqisKvLQ2C2v0/u7LVly17ak2YSgoK4PrdsYBXQIax19vhKiLfvKNFx7FRrpTnitrpzF/uuCMuorIg==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"npm-package-arg": "^6.1.0",
@@ -10830,8 +10695,7 @@
 				},
 				"lockfile": {
 					"version": "1.0.4",
-					"resolved": false,
-					"integrity": "sha512-cvbTwETRfsFh4nHsL1eGWapU1XFi5Ot9E85sWAwia7Y7EgB7vfqcZhTKZ+l7hCGxSPoushMv5GKhT5PdLv03WA==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"signal-exit": "^3.0.2"
@@ -10839,14 +10703,12 @@
 				},
 				"lodash._baseindexof": {
 					"version": "3.1.0",
-					"resolved": false,
-					"integrity": "sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw=",
+					"bundled": true,
 					"dev": true
 				},
 				"lodash._baseuniq": {
 					"version": "4.6.0",
-					"resolved": false,
-					"integrity": "sha1-DrtE5FaBSveQXGIS+iybLVG4Qeg=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"lodash._createset": "~4.0.0",
@@ -10855,20 +10717,17 @@
 				},
 				"lodash._bindcallback": {
 					"version": "3.0.1",
-					"resolved": false,
-					"integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4=",
+					"bundled": true,
 					"dev": true
 				},
 				"lodash._cacheindexof": {
 					"version": "3.0.2",
-					"resolved": false,
-					"integrity": "sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI=",
+					"bundled": true,
 					"dev": true
 				},
 				"lodash._createcache": {
 					"version": "3.1.2",
-					"resolved": false,
-					"integrity": "sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"lodash._getnative": "^3.0.0"
@@ -10876,62 +10735,52 @@
 				},
 				"lodash._createset": {
 					"version": "4.0.3",
-					"resolved": false,
-					"integrity": "sha1-D0ZZ+7CddRlPqeK4imZE02PJ/iY=",
+					"bundled": true,
 					"dev": true
 				},
 				"lodash._getnative": {
 					"version": "3.9.1",
-					"resolved": false,
-					"integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
+					"bundled": true,
 					"dev": true
 				},
 				"lodash._root": {
 					"version": "3.0.1",
-					"resolved": false,
-					"integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI=",
+					"bundled": true,
 					"dev": true
 				},
 				"lodash.clonedeep": {
 					"version": "4.5.0",
-					"resolved": false,
-					"integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
+					"bundled": true,
 					"dev": true
 				},
 				"lodash.restparam": {
 					"version": "3.6.1",
-					"resolved": false,
-					"integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
+					"bundled": true,
 					"dev": true
 				},
 				"lodash.union": {
 					"version": "4.6.0",
-					"resolved": false,
-					"integrity": "sha1-SLtQiECfFvGCFmZkHETdGqrjzYg=",
+					"bundled": true,
 					"dev": true
 				},
 				"lodash.uniq": {
 					"version": "4.5.0",
-					"resolved": false,
-					"integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
+					"bundled": true,
 					"dev": true
 				},
 				"lodash.without": {
 					"version": "4.4.0",
-					"resolved": false,
-					"integrity": "sha1-PNRXSgC2e643OpS3SHcmQFB7eqw=",
+					"bundled": true,
 					"dev": true
 				},
 				"lowercase-keys": {
 					"version": "1.0.1",
-					"resolved": false,
-					"integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
+					"bundled": true,
 					"dev": true
 				},
 				"lru-cache": {
 					"version": "5.1.1",
-					"resolved": false,
-					"integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"yallist": "^3.0.2"
@@ -10939,8 +10788,7 @@
 				},
 				"make-dir": {
 					"version": "1.3.0",
-					"resolved": false,
-					"integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"pify": "^3.0.0"
@@ -10948,8 +10796,7 @@
 				},
 				"make-fetch-happen": {
 					"version": "5.0.2",
-					"resolved": false,
-					"integrity": "sha512-07JHC0r1ykIoruKO8ifMXu+xEU8qOXDFETylktdug6vJDACnP+HKevOu3PXyNPzFyTSlz8vrBYlBO1JZRe8Cag==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"agentkeepalive": "^3.4.1",
@@ -10966,21 +10813,18 @@
 					}
 				},
 				"meant": {
-					"version": "1.0.1",
-					"resolved": false,
-					"integrity": "sha512-UakVLFjKkbbUwNWJ2frVLnnAtbb7D7DsloxRd3s/gDpI8rdv8W5Hp3NaDb+POBI1fQdeussER6NB8vpcRURvlg==",
+					"version": "1.0.2",
+					"bundled": true,
 					"dev": true
 				},
 				"mime-db": {
 					"version": "1.35.0",
-					"resolved": false,
-					"integrity": "sha512-JWT/IcCTsB0Io3AhWUMjRqucrHSPsSf2xKLaRldJVULioggvkJvggZ3VXNNSRkCddE6D+BUI4HEIZIA2OjwIvg==",
+					"bundled": true,
 					"dev": true
 				},
 				"mime-types": {
 					"version": "2.1.19",
-					"resolved": false,
-					"integrity": "sha512-P1tKYHVSZ6uFo26mtnve4HQFE3koh1UWVkp8YUC+ESBHe945xWSoXuHHiGarDqcEZ+whpCDnlNw5LON0kLo+sw==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"mime-db": "~1.35.0"
@@ -10988,17 +10832,20 @@
 				},
 				"minimatch": {
 					"version": "3.0.4",
-					"resolved": false,
-					"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
 					}
 				},
+				"minimist": {
+					"version": "1.2.5",
+					"bundled": true,
+					"dev": true
+				},
 				"minizlib": {
 					"version": "1.3.3",
-					"resolved": false,
-					"integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"minipass": "^2.9.0"
@@ -11006,8 +10853,7 @@
 					"dependencies": {
 						"minipass": {
 							"version": "2.9.0",
-							"resolved": false,
-							"integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
+							"bundled": true,
 							"dev": true,
 							"requires": {
 								"safe-buffer": "^5.1.2",
@@ -11018,8 +10864,7 @@
 				},
 				"mississippi": {
 					"version": "3.0.0",
-					"resolved": false,
-					"integrity": "sha512-x471SsVjUtBRtcvd4BzKE9kFC+/2TeWgKCgw0bZcw1b9l2X3QX5vCWgF+KaZaYm87Ss//rHnWryupDrgLvmSkA==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"concat-stream": "^1.5.0",
@@ -11036,8 +10881,7 @@
 				},
 				"mkdirp": {
 					"version": "0.5.5",
-					"resolved": false,
-					"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"minimist": "^1.2.5"
@@ -11045,16 +10889,14 @@
 					"dependencies": {
 						"minimist": {
 							"version": "1.2.5",
-							"resolved": false,
-							"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+							"bundled": true,
 							"dev": true
 						}
 					}
 				},
 				"move-concurrently": {
 					"version": "1.0.1",
-					"resolved": false,
-					"integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"aproba": "^1.1.1",
@@ -11067,28 +10909,24 @@
 					"dependencies": {
 						"aproba": {
 							"version": "1.2.0",
-							"resolved": false,
-							"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+							"bundled": true,
 							"dev": true
 						}
 					}
 				},
 				"ms": {
 					"version": "2.1.1",
-					"resolved": false,
-					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+					"bundled": true,
 					"dev": true
 				},
 				"mute-stream": {
 					"version": "0.0.7",
-					"resolved": false,
-					"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+					"bundled": true,
 					"dev": true
 				},
 				"node-fetch-npm": {
 					"version": "2.0.2",
-					"resolved": false,
-					"integrity": "sha512-nJIxm1QmAj4v3nfCvEeCrYSoVwXyxLnaPBK5W1W5DGEJwjlKuC2VEUycGw5oxk+4zZahRrB84PUJJgEmhFTDFw==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"encoding": "^0.1.11",
@@ -11098,8 +10936,7 @@
 				},
 				"node-gyp": {
 					"version": "5.1.0",
-					"resolved": false,
-					"integrity": "sha512-OUTryc5bt/P8zVgNUmC6xdXiDJxLMAW8cF5tLQOT9E5sOQj+UeQxnnPy74K3CLCa/SOjjBlbuzDLR8ANwA+wmw==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"env-paths": "^2.2.0",
@@ -11117,8 +10954,7 @@
 				},
 				"nopt": {
 					"version": "4.0.3",
-					"resolved": false,
-					"integrity": "sha512-CvaGwVMztSMJLOeXPrez7fyfObdZqNUK1cPAEzLHrTybIua9pMdmmPR5YwtfNftIOMv3DPUhFaxsZMNTQO20Kg==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"abbrev": "1",
@@ -11127,8 +10963,7 @@
 				},
 				"normalize-package-data": {
 					"version": "2.5.0",
-					"resolved": false,
-					"integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"hosted-git-info": "^2.1.4",
@@ -11139,8 +10974,7 @@
 					"dependencies": {
 						"resolve": {
 							"version": "1.10.0",
-							"resolved": false,
-							"integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
+							"bundled": true,
 							"dev": true,
 							"requires": {
 								"path-parse": "^1.0.6"
@@ -11150,8 +10984,7 @@
 				},
 				"npm-audit-report": {
 					"version": "1.3.3",
-					"resolved": "https://registry.npmjs.org/npm-audit-report/-/npm-audit-report-1.3.3.tgz",
-					"integrity": "sha512-8nH/JjsFfAWMvn474HB9mpmMjrnKb1Hx/oTAdjv4PT9iZBvBxiZ+wtDUapHCJwLqYGQVPaAfs+vL5+5k9QndXw==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"cli-table3": "^0.5.0",
@@ -11160,8 +10993,7 @@
 				},
 				"npm-bundled": {
 					"version": "1.1.1",
-					"resolved": false,
-					"integrity": "sha512-gqkfgGePhTpAEgUsGEgcq1rqPXA+tv/aVBlgEzfXwA1yiUJF7xtEt3CtVwOjNYQOVknDk0F20w58Fnm3EtG0fA==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"npm-normalize-package-bin": "^1.0.1"
@@ -11169,14 +11001,12 @@
 				},
 				"npm-cache-filename": {
 					"version": "1.0.2",
-					"resolved": false,
-					"integrity": "sha1-3tMGxbC/yHCp6fr4I7xfKD4FrhE=",
+					"bundled": true,
 					"dev": true
 				},
 				"npm-install-checks": {
 					"version": "3.0.2",
-					"resolved": false,
-					"integrity": "sha512-E4kzkyZDIWoin6uT5howP8VDvkM+E8IQDcHAycaAxMbwkqhIg5eEYALnXOl3Hq9MrkdQB/2/g1xwBINXdKSRkg==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"semver": "^2.3.0 || 3.x || 4 || 5"
@@ -11184,8 +11014,7 @@
 				},
 				"npm-lifecycle": {
 					"version": "3.1.5",
-					"resolved": "https://registry.npmjs.org/npm-lifecycle/-/npm-lifecycle-3.1.5.tgz",
-					"integrity": "sha512-lDLVkjfZmvmfvpvBzA4vzee9cn+Me4orq0QF8glbswJVEbIcSNWib7qGOffolysc3teCqbbPZZkzbr3GQZTL1g==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"byline": "^5.0.0",
@@ -11200,20 +11029,17 @@
 				},
 				"npm-logical-tree": {
 					"version": "1.2.1",
-					"resolved": false,
-					"integrity": "sha512-AJI/qxDB2PWI4LG1CYN579AY1vCiNyWfkiquCsJWqntRu/WwimVrC8yXeILBFHDwxfOejxewlmnvW9XXjMlYIg==",
+					"bundled": true,
 					"dev": true
 				},
 				"npm-normalize-package-bin": {
 					"version": "1.0.1",
-					"resolved": false,
-					"integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==",
+					"bundled": true,
 					"dev": true
 				},
 				"npm-package-arg": {
 					"version": "6.1.1",
-					"resolved": false,
-					"integrity": "sha512-qBpssaL3IOZWi5vEKUKW0cO7kzLeT+EQO9W8RsLOZf76KF9E/K9+wH0C7t06HXPpaH8WH5xF1MExLuCwbTqRUg==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"hosted-git-info": "^2.7.1",
@@ -11224,8 +11050,7 @@
 				},
 				"npm-packlist": {
 					"version": "1.4.8",
-					"resolved": false,
-					"integrity": "sha512-5+AZgwru5IevF5ZdnFglB5wNlHG1AOOuw28WhUq8/8emhBmLv6jX5by4WJCh7lW0uSYZYS6DXqIsyZVIXRZU9A==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"ignore-walk": "^3.0.1",
@@ -11235,8 +11060,7 @@
 				},
 				"npm-pick-manifest": {
 					"version": "3.0.2",
-					"resolved": false,
-					"integrity": "sha512-wNprTNg+X5nf+tDi+hbjdHhM4bX+mKqv6XmPh7B5eG+QY9VARfQPfCEH013H5GqfNj6ee8Ij2fg8yk0mzps1Vw==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"figgy-pudding": "^3.5.1",
@@ -11246,8 +11070,7 @@
 				},
 				"npm-profile": {
 					"version": "4.0.4",
-					"resolved": false,
-					"integrity": "sha512-Ta8xq8TLMpqssF0H60BXS1A90iMoM6GeKwsmravJ6wYjWwSzcYBTdyWa3DZCYqPutacBMEm7cxiOkiIeCUAHDQ==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"aproba": "^1.1.2 || 2",
@@ -11256,9 +11079,8 @@
 					}
 				},
 				"npm-registry-fetch": {
-					"version": "4.0.5",
-					"resolved": false,
-					"integrity": "sha512-yQ0/U4fYpCCqmueB2g8sc+89ckQ3eXpmU4+Yi2j5o/r0WkKvE2+Y0tK3DEILAtn2UaQTkjTHxIXe2/CSdit+/Q==",
+					"version": "4.0.7",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"JSONStream": "^1.3.4",
@@ -11272,31 +11094,27 @@
 					"dependencies": {
 						"safe-buffer": {
 							"version": "5.2.1",
-							"resolved": false,
-							"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+							"bundled": true,
 							"dev": true
 						}
 					}
 				},
 				"npm-run-path": {
 					"version": "2.0.2",
-					"resolved": false,
-					"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"path-key": "^2.0.0"
 					}
 				},
 				"npm-user-validate": {
-					"version": "1.0.0",
-					"resolved": false,
-					"integrity": "sha1-jOyg9c6gTU6TUZ73LQVXp1Ei6VE=",
+					"version": "1.0.1",
+					"bundled": true,
 					"dev": true
 				},
 				"npmlog": {
 					"version": "4.1.2",
-					"resolved": false,
-					"integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"are-we-there-yet": "~1.1.2",
@@ -11307,32 +11125,27 @@
 				},
 				"number-is-nan": {
 					"version": "1.0.1",
-					"resolved": false,
-					"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+					"bundled": true,
 					"dev": true
 				},
 				"oauth-sign": {
 					"version": "0.9.0",
-					"resolved": false,
-					"integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+					"bundled": true,
 					"dev": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
-					"resolved": false,
-					"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+					"bundled": true,
 					"dev": true
 				},
 				"object-keys": {
 					"version": "1.0.12",
-					"resolved": false,
-					"integrity": "sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag==",
+					"bundled": true,
 					"dev": true
 				},
 				"object.getownpropertydescriptors": {
 					"version": "2.0.3",
-					"resolved": false,
-					"integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"define-properties": "^1.1.2",
@@ -11341,8 +11154,7 @@
 				},
 				"once": {
 					"version": "1.4.0",
-					"resolved": false,
-					"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"wrappy": "1"
@@ -11350,26 +11162,22 @@
 				},
 				"opener": {
 					"version": "1.5.1",
-					"resolved": false,
-					"integrity": "sha512-goYSy5c2UXE4Ra1xixabeVh1guIX/ZV/YokJksb6q2lubWu6UbvPQ20p542/sFIll1nl8JnCyK9oBaOcCWXwvA==",
+					"bundled": true,
 					"dev": true
 				},
 				"os-homedir": {
 					"version": "1.0.2",
-					"resolved": false,
-					"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+					"bundled": true,
 					"dev": true
 				},
 				"os-tmpdir": {
 					"version": "1.0.2",
-					"resolved": false,
-					"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+					"bundled": true,
 					"dev": true
 				},
 				"osenv": {
 					"version": "0.1.5",
-					"resolved": false,
-					"integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"os-homedir": "^1.0.0",
@@ -11378,14 +11186,12 @@
 				},
 				"p-finally": {
 					"version": "1.0.0",
-					"resolved": false,
-					"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+					"bundled": true,
 					"dev": true
 				},
 				"package-json": {
 					"version": "4.0.1",
-					"resolved": false,
-					"integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"got": "^6.7.1",
@@ -11396,8 +11202,7 @@
 				},
 				"pacote": {
 					"version": "9.5.12",
-					"resolved": false,
-					"integrity": "sha512-BUIj/4kKbwWg4RtnBncXPJd15piFSVNpTzY0rysSr3VnMowTYgkGKcaHrbReepAkjTr8lH2CVWRi58Spg2CicQ==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"bluebird": "^3.5.3",
@@ -11434,8 +11239,7 @@
 					"dependencies": {
 						"minipass": {
 							"version": "2.9.0",
-							"resolved": false,
-							"integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
+							"bundled": true,
 							"dev": true,
 							"requires": {
 								"safe-buffer": "^5.1.2",
@@ -11446,8 +11250,7 @@
 				},
 				"parallel-transform": {
 					"version": "1.1.0",
-					"resolved": false,
-					"integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"cyclist": "~0.2.2",
@@ -11457,8 +11260,7 @@
 					"dependencies": {
 						"readable-stream": {
 							"version": "2.3.6",
-							"resolved": false,
-							"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+							"bundled": true,
 							"dev": true,
 							"requires": {
 								"core-util-is": "~1.0.0",
@@ -11472,8 +11274,7 @@
 						},
 						"string_decoder": {
 							"version": "1.1.1",
-							"resolved": false,
-							"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+							"bundled": true,
 							"dev": true,
 							"requires": {
 								"safe-buffer": "~5.1.0"
@@ -11483,68 +11284,57 @@
 				},
 				"path-exists": {
 					"version": "3.0.0",
-					"resolved": false,
-					"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+					"bundled": true,
 					"dev": true
 				},
 				"path-is-absolute": {
 					"version": "1.0.1",
-					"resolved": false,
-					"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+					"bundled": true,
 					"dev": true
 				},
 				"path-is-inside": {
 					"version": "1.0.2",
-					"resolved": false,
-					"integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+					"bundled": true,
 					"dev": true
 				},
 				"path-key": {
 					"version": "2.0.1",
-					"resolved": false,
-					"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+					"bundled": true,
 					"dev": true
 				},
 				"path-parse": {
 					"version": "1.0.6",
-					"resolved": false,
-					"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+					"bundled": true,
 					"dev": true
 				},
 				"performance-now": {
 					"version": "2.1.0",
-					"resolved": false,
-					"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+					"bundled": true,
 					"dev": true
 				},
 				"pify": {
 					"version": "3.0.0",
-					"resolved": false,
-					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+					"bundled": true,
 					"dev": true
 				},
 				"prepend-http": {
 					"version": "1.0.4",
-					"resolved": false,
-					"integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
+					"bundled": true,
 					"dev": true
 				},
 				"process-nextick-args": {
 					"version": "2.0.0",
-					"resolved": false,
-					"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+					"bundled": true,
 					"dev": true
 				},
 				"promise-inflight": {
 					"version": "1.0.1",
-					"resolved": false,
-					"integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
+					"bundled": true,
 					"dev": true
 				},
 				"promise-retry": {
 					"version": "1.1.1",
-					"resolved": false,
-					"integrity": "sha1-ZznpaOMFHaIM5kl/srUPaRHfPW0=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"err-code": "^1.0.0",
@@ -11553,16 +11343,14 @@
 					"dependencies": {
 						"retry": {
 							"version": "0.10.1",
-							"resolved": false,
-							"integrity": "sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q=",
+							"bundled": true,
 							"dev": true
 						}
 					}
 				},
 				"promzard": {
 					"version": "0.3.0",
-					"resolved": false,
-					"integrity": "sha1-JqXW7ox97kyxIggwWs+5O6OCqe4=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"read": "1"
@@ -11570,14 +11358,12 @@
 				},
 				"proto-list": {
 					"version": "1.2.4",
-					"resolved": false,
-					"integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
+					"bundled": true,
 					"dev": true
 				},
 				"protoduck": {
 					"version": "5.0.1",
-					"resolved": false,
-					"integrity": "sha512-WxoCeDCoCBY55BMvj4cAEjdVUFGRWed9ZxPlqTKYyw1nDDTQ4pqmnIMAGfJlg7Dx35uB/M+PHJPTmGOvaCaPTg==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"genfun": "^5.0.0"
@@ -11585,26 +11371,22 @@
 				},
 				"prr": {
 					"version": "1.0.1",
-					"resolved": false,
-					"integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
+					"bundled": true,
 					"dev": true
 				},
 				"pseudomap": {
 					"version": "1.0.2",
-					"resolved": false,
-					"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+					"bundled": true,
 					"dev": true
 				},
 				"psl": {
 					"version": "1.1.29",
-					"resolved": false,
-					"integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ==",
+					"bundled": true,
 					"dev": true
 				},
 				"pump": {
 					"version": "3.0.0",
-					"resolved": false,
-					"integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"end-of-stream": "^1.1.0",
@@ -11613,8 +11395,7 @@
 				},
 				"pumpify": {
 					"version": "1.5.1",
-					"resolved": false,
-					"integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"duplexify": "^3.6.0",
@@ -11624,8 +11405,7 @@
 					"dependencies": {
 						"pump": {
 							"version": "2.0.1",
-							"resolved": false,
-							"integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
+							"bundled": true,
 							"dev": true,
 							"requires": {
 								"end-of-stream": "^1.1.0",
@@ -11636,26 +11416,22 @@
 				},
 				"punycode": {
 					"version": "1.4.1",
-					"resolved": false,
-					"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+					"bundled": true,
 					"dev": true
 				},
 				"qrcode-terminal": {
 					"version": "0.12.0",
-					"resolved": false,
-					"integrity": "sha512-EXtzRZmC+YGmGlDFbXKxQiMZNwCLEO6BANKXG4iCtSIM0yqc/pappSx3RIKr4r0uh5JsBckOXeKrB3Iz7mdQpQ==",
+					"bundled": true,
 					"dev": true
 				},
 				"qs": {
 					"version": "6.5.2",
-					"resolved": false,
-					"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+					"bundled": true,
 					"dev": true
 				},
 				"query-string": {
 					"version": "6.8.2",
-					"resolved": false,
-					"integrity": "sha512-J3Qi8XZJXh93t2FiKyd/7Ec6GNifsjKXUsVFkSBj/kjLsDylWhnCz4NT1bkPcKotttPW+QbKGqqPH8OoI2pdqw==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"decode-uri-component": "^0.2.0",
@@ -11665,34 +11441,23 @@
 				},
 				"qw": {
 					"version": "1.0.1",
-					"resolved": false,
-					"integrity": "sha1-77/cdA+a0FQwRCassYNBLMi5ltQ=",
+					"bundled": true,
 					"dev": true
 				},
 				"rc": {
 					"version": "1.2.8",
-					"resolved": false,
-					"integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"deep-extend": "^0.6.0",
 						"ini": "~1.3.0",
 						"minimist": "^1.2.0",
 						"strip-json-comments": "~2.0.1"
-					},
-					"dependencies": {
-						"minimist": {
-							"version": "1.2.5",
-							"resolved": false,
-							"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-							"dev": true
-						}
 					}
 				},
 				"read": {
 					"version": "1.0.7",
-					"resolved": false,
-					"integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"mute-stream": "~0.0.4"
@@ -11700,8 +11465,7 @@
 				},
 				"read-cmd-shim": {
 					"version": "1.0.5",
-					"resolved": false,
-					"integrity": "sha512-v5yCqQ/7okKoZZkBQUAfTsQ3sVJtXdNfbPnI5cceppoxEVLYA3k+VtV2omkeo8MS94JCy4fSiUwlRBAwCVRPUA==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.2"
@@ -11709,8 +11473,7 @@
 				},
 				"read-installed": {
 					"version": "4.0.3",
-					"resolved": false,
-					"integrity": "sha1-/5uLZ/GH0eTCm5/rMfayI6zRkGc=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"debuglog": "^1.0.1",
@@ -11724,8 +11487,7 @@
 				},
 				"read-package-json": {
 					"version": "2.1.1",
-					"resolved": false,
-					"integrity": "sha512-dAiqGtVc/q5doFz6096CcnXhpYk0ZN8dEKVkGLU0CsASt8SrgF6SF7OTKAYubfvFhWaqofl+Y8HK19GR8jwW+A==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"glob": "^7.1.1",
@@ -11737,8 +11499,7 @@
 				},
 				"read-package-tree": {
 					"version": "5.3.1",
-					"resolved": false,
-					"integrity": "sha512-mLUDsD5JVtlZxjSlPPx1RETkNjjvQYuweKwNVt1Sn8kP5Jh44pvYuUHCp6xSVDZWbNxVxG5lyZJ921aJH61sTw==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"read-package-json": "^2.0.0",
@@ -11748,8 +11509,7 @@
 				},
 				"readable-stream": {
 					"version": "3.6.0",
-					"resolved": false,
-					"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"inherits": "^2.0.3",
@@ -11759,8 +11519,7 @@
 				},
 				"readdir-scoped-modules": {
 					"version": "1.1.0",
-					"resolved": false,
-					"integrity": "sha512-asaikDeqAQg7JifRsZn1NJZXo9E+VwlyCfbkZhwyISinqk5zNS6266HS5kah6P0SaQKGF6SkNnZVHUzHFYxYDw==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"debuglog": "^1.0.1",
@@ -11771,8 +11530,7 @@
 				},
 				"registry-auth-token": {
 					"version": "3.4.0",
-					"resolved": false,
-					"integrity": "sha512-4LM6Fw8eBQdwMYcES4yTnn2TqIasbXuwDx3um+QRs7S55aMKCBKBxvPXl2RiUjHwuJLTyYfxSpmfSAjQpcuP+A==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"rc": "^1.1.6",
@@ -11781,8 +11539,7 @@
 				},
 				"registry-url": {
 					"version": "3.1.0",
-					"resolved": false,
-					"integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"rc": "^1.0.1"
@@ -11790,8 +11547,7 @@
 				},
 				"request": {
 					"version": "2.88.0",
-					"resolved": false,
-					"integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"aws-sign2": "~0.7.0",
@@ -11818,32 +11574,27 @@
 				},
 				"require-directory": {
 					"version": "2.1.1",
-					"resolved": false,
-					"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+					"bundled": true,
 					"dev": true
 				},
 				"require-main-filename": {
 					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-					"integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+					"bundled": true,
 					"dev": true
 				},
 				"resolve-from": {
 					"version": "4.0.0",
-					"resolved": false,
-					"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+					"bundled": true,
 					"dev": true
 				},
 				"retry": {
 					"version": "0.12.0",
-					"resolved": false,
-					"integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
+					"bundled": true,
 					"dev": true
 				},
 				"rimraf": {
 					"version": "2.7.1",
-					"resolved": false,
-					"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"glob": "^7.1.3"
@@ -11851,8 +11602,7 @@
 				},
 				"run-queue": {
 					"version": "1.0.3",
-					"resolved": false,
-					"integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"aproba": "^1.1.1"
@@ -11860,34 +11610,29 @@
 					"dependencies": {
 						"aproba": {
 							"version": "1.2.0",
-							"resolved": false,
-							"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+							"bundled": true,
 							"dev": true
 						}
 					}
 				},
 				"safe-buffer": {
 					"version": "5.1.2",
-					"resolved": false,
-					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+					"bundled": true,
 					"dev": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
-					"resolved": false,
-					"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+					"bundled": true,
 					"dev": true
 				},
 				"semver": {
 					"version": "5.7.1",
-					"resolved": false,
-					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+					"bundled": true,
 					"dev": true
 				},
 				"semver-diff": {
 					"version": "2.1.0",
-					"resolved": false,
-					"integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"semver": "^5.0.3"
@@ -11895,14 +11640,12 @@
 				},
 				"set-blocking": {
 					"version": "2.0.0",
-					"resolved": false,
-					"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+					"bundled": true,
 					"dev": true
 				},
 				"sha": {
 					"version": "3.0.0",
-					"resolved": false,
-					"integrity": "sha512-DOYnM37cNsLNSGIG/zZWch5CKIRNoLdYUQTQlcgkRkoYIUwDYjqDyye16YcDZg/OPdcbUgTKMjc4SY6TB7ZAPw==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.2"
@@ -11910,8 +11653,7 @@
 				},
 				"shebang-command": {
 					"version": "1.2.0",
-					"resolved": false,
-					"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"shebang-regex": "^1.0.0"
@@ -11919,32 +11661,27 @@
 				},
 				"shebang-regex": {
 					"version": "1.0.0",
-					"resolved": false,
-					"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+					"bundled": true,
 					"dev": true
 				},
 				"signal-exit": {
 					"version": "3.0.2",
-					"resolved": false,
-					"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+					"bundled": true,
 					"dev": true
 				},
 				"slide": {
 					"version": "1.1.6",
-					"resolved": false,
-					"integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
+					"bundled": true,
 					"dev": true
 				},
 				"smart-buffer": {
 					"version": "4.1.0",
-					"resolved": false,
-					"integrity": "sha512-iVICrxOzCynf/SNaBQCw34eM9jROU/s5rzIhpOvzhzuYHfJR/DhZfDkXiZSgKXfgv26HT3Yni3AV/DGw0cGnnw==",
+					"bundled": true,
 					"dev": true
 				},
 				"socks": {
 					"version": "2.3.3",
-					"resolved": false,
-					"integrity": "sha512-o5t52PCNtVdiOvzMry7wU4aOqYWL0PeCXRWBEiJow4/i/wr+wpsJQ9awEu1EonLIqsfGd5qSgDdxEOvCdmBEpA==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"ip": "1.1.5",
@@ -11953,8 +11690,7 @@
 				},
 				"socks-proxy-agent": {
 					"version": "4.0.2",
-					"resolved": false,
-					"integrity": "sha512-NT6syHhI9LmuEMSK6Kd2V7gNv5KFZoLE7V5udWmn0de+3Mkj3UMA/AJPLyeNUVmElCurSHtUdM3ETpR3z770Wg==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"agent-base": "~4.2.1",
@@ -11963,8 +11699,7 @@
 					"dependencies": {
 						"agent-base": {
 							"version": "4.2.1",
-							"resolved": false,
-							"integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
+							"bundled": true,
 							"dev": true,
 							"requires": {
 								"es6-promisify": "^5.0.0"
@@ -11974,14 +11709,12 @@
 				},
 				"sorted-object": {
 					"version": "2.0.1",
-					"resolved": false,
-					"integrity": "sha1-fWMfS9OnmKJK8d/8+/6DM3pd9fw=",
+					"bundled": true,
 					"dev": true
 				},
 				"sorted-union-stream": {
 					"version": "2.1.3",
-					"resolved": false,
-					"integrity": "sha1-x3lMfgd4gAUv9xqNSi27Sppjisc=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"from2": "^1.3.0",
@@ -11990,8 +11723,7 @@
 					"dependencies": {
 						"from2": {
 							"version": "1.3.0",
-							"resolved": false,
-							"integrity": "sha1-iEE7qqX5pZfP3pIh2GmGzTwGHf0=",
+							"bundled": true,
 							"dev": true,
 							"requires": {
 								"inherits": "~2.0.1",
@@ -12000,14 +11732,12 @@
 						},
 						"isarray": {
 							"version": "0.0.1",
-							"resolved": false,
-							"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+							"bundled": true,
 							"dev": true
 						},
 						"readable-stream": {
 							"version": "1.1.14",
-							"resolved": false,
-							"integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+							"bundled": true,
 							"dev": true,
 							"requires": {
 								"core-util-is": "~1.0.0",
@@ -12018,16 +11748,14 @@
 						},
 						"string_decoder": {
 							"version": "0.10.31",
-							"resolved": false,
-							"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+							"bundled": true,
 							"dev": true
 						}
 					}
 				},
 				"spdx-correct": {
 					"version": "3.0.0",
-					"resolved": false,
-					"integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"spdx-expression-parse": "^3.0.0",
@@ -12036,14 +11764,12 @@
 				},
 				"spdx-exceptions": {
 					"version": "2.1.0",
-					"resolved": false,
-					"integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg==",
+					"bundled": true,
 					"dev": true
 				},
 				"spdx-expression-parse": {
 					"version": "3.0.0",
-					"resolved": false,
-					"integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"spdx-exceptions": "^2.1.0",
@@ -12052,20 +11778,17 @@
 				},
 				"spdx-license-ids": {
 					"version": "3.0.5",
-					"resolved": false,
-					"integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
+					"bundled": true,
 					"dev": true
 				},
 				"split-on-first": {
 					"version": "1.1.0",
-					"resolved": false,
-					"integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==",
+					"bundled": true,
 					"dev": true
 				},
 				"sshpk": {
 					"version": "1.14.2",
-					"resolved": false,
-					"integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"asn1": "~0.2.3",
@@ -12081,8 +11804,7 @@
 				},
 				"ssri": {
 					"version": "6.0.1",
-					"resolved": false,
-					"integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"figgy-pudding": "^3.5.1"
@@ -12090,8 +11812,7 @@
 				},
 				"stream-each": {
 					"version": "1.2.2",
-					"resolved": false,
-					"integrity": "sha512-mc1dbFhGBxvTM3bIWmAAINbqiuAk9TATcfIQC8P+/+HJefgaiTlMn2dHvkX8qlI12KeYKSQ1Ua9RrIqrn1VPoA==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"end-of-stream": "^1.1.0",
@@ -12100,8 +11821,7 @@
 				},
 				"stream-iterate": {
 					"version": "1.2.0",
-					"resolved": false,
-					"integrity": "sha1-K9fHcpbBcCpGSIuK1B95hl7s1OE=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"readable-stream": "^2.1.5",
@@ -12110,8 +11830,7 @@
 					"dependencies": {
 						"readable-stream": {
 							"version": "2.3.6",
-							"resolved": false,
-							"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+							"bundled": true,
 							"dev": true,
 							"requires": {
 								"core-util-is": "~1.0.0",
@@ -12125,8 +11844,7 @@
 						},
 						"string_decoder": {
 							"version": "1.1.1",
-							"resolved": false,
-							"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+							"bundled": true,
 							"dev": true,
 							"requires": {
 								"safe-buffer": "~5.1.0"
@@ -12136,20 +11854,17 @@
 				},
 				"stream-shift": {
 					"version": "1.0.0",
-					"resolved": false,
-					"integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
+					"bundled": true,
 					"dev": true
 				},
 				"strict-uri-encode": {
 					"version": "2.0.0",
-					"resolved": false,
-					"integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY=",
+					"bundled": true,
 					"dev": true
 				},
 				"string-width": {
 					"version": "2.1.1",
-					"resolved": false,
-					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"is-fullwidth-code-point": "^2.0.0",
@@ -12158,20 +11873,17 @@
 					"dependencies": {
 						"ansi-regex": {
 							"version": "3.0.0",
-							"resolved": false,
-							"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+							"bundled": true,
 							"dev": true
 						},
 						"is-fullwidth-code-point": {
 							"version": "2.0.0",
-							"resolved": false,
-							"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+							"bundled": true,
 							"dev": true
 						},
 						"strip-ansi": {
 							"version": "4.0.0",
-							"resolved": false,
-							"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+							"bundled": true,
 							"dev": true,
 							"requires": {
 								"ansi-regex": "^3.0.0"
@@ -12181,8 +11893,7 @@
 				},
 				"string_decoder": {
 					"version": "1.3.0",
-					"resolved": false,
-					"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"safe-buffer": "~5.2.0"
@@ -12190,22 +11901,19 @@
 					"dependencies": {
 						"safe-buffer": {
 							"version": "5.2.0",
-							"resolved": false,
-							"integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==",
+							"bundled": true,
 							"dev": true
 						}
 					}
 				},
 				"stringify-package": {
 					"version": "1.0.1",
-					"resolved": false,
-					"integrity": "sha512-sa4DUQsYciMP1xhKWGuFM04fB0LG/9DlluZoSVywUMRNvzid6XucHK0/90xGxRoHrAaROrcHK1aPKaijCtSrhg==",
+					"bundled": true,
 					"dev": true
 				},
 				"strip-ansi": {
 					"version": "3.0.1",
-					"resolved": false,
-					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
@@ -12213,20 +11921,17 @@
 				},
 				"strip-eof": {
 					"version": "1.0.0",
-					"resolved": false,
-					"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+					"bundled": true,
 					"dev": true
 				},
 				"strip-json-comments": {
 					"version": "2.0.1",
-					"resolved": false,
-					"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+					"bundled": true,
 					"dev": true
 				},
 				"supports-color": {
 					"version": "5.4.0",
-					"resolved": false,
-					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"has-flag": "^3.0.0"
@@ -12234,8 +11939,7 @@
 				},
 				"tar": {
 					"version": "4.4.13",
-					"resolved": false,
-					"integrity": "sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"chownr": "^1.1.1",
@@ -12249,8 +11953,7 @@
 					"dependencies": {
 						"minipass": {
 							"version": "2.9.0",
-							"resolved": false,
-							"integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
+							"bundled": true,
 							"dev": true,
 							"requires": {
 								"safe-buffer": "^5.1.2",
@@ -12261,8 +11964,7 @@
 				},
 				"term-size": {
 					"version": "1.2.0",
-					"resolved": false,
-					"integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"execa": "^0.7.0"
@@ -12270,20 +11972,17 @@
 				},
 				"text-table": {
 					"version": "0.2.0",
-					"resolved": false,
-					"integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+					"bundled": true,
 					"dev": true
 				},
 				"through": {
 					"version": "2.3.8",
-					"resolved": false,
-					"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+					"bundled": true,
 					"dev": true
 				},
 				"through2": {
 					"version": "2.0.3",
-					"resolved": false,
-					"integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"readable-stream": "^2.1.5",
@@ -12292,8 +11991,7 @@
 					"dependencies": {
 						"readable-stream": {
 							"version": "2.3.6",
-							"resolved": false,
-							"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+							"bundled": true,
 							"dev": true,
 							"requires": {
 								"core-util-is": "~1.0.0",
@@ -12307,8 +12005,7 @@
 						},
 						"string_decoder": {
 							"version": "1.1.1",
-							"resolved": false,
-							"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+							"bundled": true,
 							"dev": true,
 							"requires": {
 								"safe-buffer": "~5.1.0"
@@ -12318,20 +12015,17 @@
 				},
 				"timed-out": {
 					"version": "4.0.1",
-					"resolved": false,
-					"integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
+					"bundled": true,
 					"dev": true
 				},
 				"tiny-relative-date": {
 					"version": "1.3.0",
-					"resolved": false,
-					"integrity": "sha512-MOQHpzllWxDCHHaDno30hhLfbouoYlOI8YlMNtvKe1zXbjEVhbcEovQxvZrPvtiYW630GQDoMMarCnjfyfHA+A==",
+					"bundled": true,
 					"dev": true
 				},
 				"tough-cookie": {
 					"version": "2.4.3",
-					"resolved": false,
-					"integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"psl": "^1.1.24",
@@ -12340,8 +12034,7 @@
 				},
 				"tunnel-agent": {
 					"version": "0.6.0",
-					"resolved": false,
-					"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"safe-buffer": "^5.0.1"
@@ -12349,33 +12042,28 @@
 				},
 				"tweetnacl": {
 					"version": "0.14.5",
-					"resolved": false,
-					"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+					"bundled": true,
 					"dev": true,
 					"optional": true
 				},
 				"typedarray": {
 					"version": "0.0.6",
-					"resolved": false,
-					"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+					"bundled": true,
 					"dev": true
 				},
 				"uid-number": {
 					"version": "0.0.6",
-					"resolved": false,
-					"integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
+					"bundled": true,
 					"dev": true
 				},
 				"umask": {
 					"version": "1.1.0",
-					"resolved": false,
-					"integrity": "sha1-8pzr8B31F5ErtY/5xOUP3o4zMg0=",
+					"bundled": true,
 					"dev": true
 				},
 				"unique-filename": {
 					"version": "1.1.1",
-					"resolved": false,
-					"integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"unique-slug": "^2.0.0"
@@ -12383,8 +12071,7 @@
 				},
 				"unique-slug": {
 					"version": "2.0.0",
-					"resolved": false,
-					"integrity": "sha1-22Z258fMBimHj/GWCXx4hVrp9Ks=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"imurmurhash": "^0.1.4"
@@ -12392,8 +12079,7 @@
 				},
 				"unique-string": {
 					"version": "1.0.0",
-					"resolved": false,
-					"integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"crypto-random-string": "^1.0.0"
@@ -12401,20 +12087,17 @@
 				},
 				"unpipe": {
 					"version": "1.0.0",
-					"resolved": false,
-					"integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
+					"bundled": true,
 					"dev": true
 				},
 				"unzip-response": {
 					"version": "2.0.1",
-					"resolved": false,
-					"integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c=",
+					"bundled": true,
 					"dev": true
 				},
 				"update-notifier": {
 					"version": "2.5.0",
-					"resolved": false,
-					"integrity": "sha512-gwMdhgJHGuj/+wHJJs9e6PcCszpxR1b236igrOkUofGhqJuG+amlIKwApH1IW1WWl7ovZxsX49lMBWLxSdm5Dw==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"boxen": "^1.2.1",
@@ -12429,10 +12112,24 @@
 						"xdg-basedir": "^3.0.0"
 					}
 				},
+				"uri-js": {
+					"version": "4.4.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"punycode": "^2.1.0"
+					},
+					"dependencies": {
+						"punycode": {
+							"version": "2.1.1",
+							"bundled": true,
+							"dev": true
+						}
+					}
+				},
 				"url-parse-lax": {
 					"version": "1.0.0",
-					"resolved": false,
-					"integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"prepend-http": "^1.0.1"
@@ -12440,20 +12137,17 @@
 				},
 				"util-deprecate": {
 					"version": "1.0.2",
-					"resolved": false,
-					"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+					"bundled": true,
 					"dev": true
 				},
 				"util-extend": {
 					"version": "1.0.3",
-					"resolved": false,
-					"integrity": "sha1-p8IW0mdUUWljeztu3GypEZ4v+T8=",
+					"bundled": true,
 					"dev": true
 				},
 				"util-promisify": {
 					"version": "2.1.0",
-					"resolved": false,
-					"integrity": "sha1-PCI2R2xNMsX/PEcAKt18E7moKlM=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"object.getownpropertydescriptors": "^2.0.3"
@@ -12461,14 +12155,12 @@
 				},
 				"uuid": {
 					"version": "3.3.3",
-					"resolved": false,
-					"integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==",
+					"bundled": true,
 					"dev": true
 				},
 				"validate-npm-package-license": {
 					"version": "3.0.4",
-					"resolved": false,
-					"integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"spdx-correct": "^3.0.0",
@@ -12477,8 +12169,7 @@
 				},
 				"validate-npm-package-name": {
 					"version": "3.0.0",
-					"resolved": false,
-					"integrity": "sha1-X6kS2B630MdK/BQN5zF/DKffQ34=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"builtins": "^1.0.3"
@@ -12486,8 +12177,7 @@
 				},
 				"verror": {
 					"version": "1.10.0",
-					"resolved": false,
-					"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"assert-plus": "^1.0.0",
@@ -12497,8 +12187,7 @@
 				},
 				"wcwidth": {
 					"version": "1.0.1",
-					"resolved": false,
-					"integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"defaults": "^1.0.3"
@@ -12506,8 +12195,7 @@
 				},
 				"which": {
 					"version": "1.3.1",
-					"resolved": false,
-					"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"isexe": "^2.0.0"
@@ -12515,14 +12203,12 @@
 				},
 				"which-module": {
 					"version": "2.0.0",
-					"resolved": false,
-					"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+					"bundled": true,
 					"dev": true
 				},
 				"wide-align": {
 					"version": "1.1.2",
-					"resolved": false,
-					"integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"string-width": "^1.0.2"
@@ -12530,8 +12216,7 @@
 					"dependencies": {
 						"string-width": {
 							"version": "1.0.2",
-							"resolved": false,
-							"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+							"bundled": true,
 							"dev": true,
 							"requires": {
 								"code-point-at": "^1.0.0",
@@ -12543,8 +12228,7 @@
 				},
 				"widest-line": {
 					"version": "2.0.1",
-					"resolved": false,
-					"integrity": "sha512-Ba5m9/Fa4Xt9eb2ELXt77JxVDV8w7qQrH0zS/TWSJdLyAwQjWoOzpzj5lwVftDz6n/EOu3tNACS84v509qwnJA==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"string-width": "^2.1.1"
@@ -12552,8 +12236,7 @@
 				},
 				"worker-farm": {
 					"version": "1.7.0",
-					"resolved": false,
-					"integrity": "sha512-rvw3QTZc8lAxyVrqcSGVm5yP/IJ2UcB3U0graE3LCFoZ0Yn2x4EoVSqJKdB/T5M+FLcRPjz4TDacRf3OCfNUzw==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"errno": "~0.1.7"
@@ -12561,8 +12244,7 @@
 				},
 				"wrap-ansi": {
 					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
-					"integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"ansi-styles": "^3.2.0",
@@ -12572,20 +12254,17 @@
 					"dependencies": {
 						"ansi-regex": {
 							"version": "4.1.0",
-							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-							"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+							"bundled": true,
 							"dev": true
 						},
 						"is-fullwidth-code-point": {
 							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-							"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+							"bundled": true,
 							"dev": true
 						},
 						"string-width": {
 							"version": "3.1.0",
-							"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-							"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+							"bundled": true,
 							"dev": true,
 							"requires": {
 								"emoji-regex": "^7.0.1",
@@ -12595,8 +12274,7 @@
 						},
 						"strip-ansi": {
 							"version": "5.2.0",
-							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-							"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+							"bundled": true,
 							"dev": true,
 							"requires": {
 								"ansi-regex": "^4.1.0"
@@ -12606,14 +12284,12 @@
 				},
 				"wrappy": {
 					"version": "1.0.2",
-					"resolved": false,
-					"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+					"bundled": true,
 					"dev": true
 				},
 				"write-file-atomic": {
 					"version": "2.4.3",
-					"resolved": false,
-					"integrity": "sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.11",
@@ -12623,32 +12299,27 @@
 				},
 				"xdg-basedir": {
 					"version": "3.0.0",
-					"resolved": false,
-					"integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
+					"bundled": true,
 					"dev": true
 				},
 				"xtend": {
 					"version": "4.0.1",
-					"resolved": false,
-					"integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+					"bundled": true,
 					"dev": true
 				},
 				"y18n": {
 					"version": "4.0.0",
-					"resolved": false,
-					"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+					"bundled": true,
 					"dev": true
 				},
 				"yallist": {
 					"version": "3.0.3",
-					"resolved": false,
-					"integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
+					"bundled": true,
 					"dev": true
 				},
 				"yargs": {
 					"version": "14.2.3",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-14.2.3.tgz",
-					"integrity": "sha512-ZbotRWhF+lkjijC/VhmOT9wSgyBQ7+zr13+YLkhfsSiTriYsMzkTUFP18pFhWwBeMa5gUc1MzbhrO6/VB7c9Xg==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"cliui": "^5.0.0",
@@ -12666,14 +12337,12 @@
 					"dependencies": {
 						"ansi-regex": {
 							"version": "4.1.0",
-							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-							"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+							"bundled": true,
 							"dev": true
 						},
 						"find-up": {
 							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-							"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+							"bundled": true,
 							"dev": true,
 							"requires": {
 								"locate-path": "^3.0.0"
@@ -12681,14 +12350,12 @@
 						},
 						"is-fullwidth-code-point": {
 							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-							"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+							"bundled": true,
 							"dev": true
 						},
 						"locate-path": {
 							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-							"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+							"bundled": true,
 							"dev": true,
 							"requires": {
 								"p-locate": "^3.0.0",
@@ -12697,8 +12364,7 @@
 						},
 						"p-limit": {
 							"version": "2.3.0",
-							"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-							"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+							"bundled": true,
 							"dev": true,
 							"requires": {
 								"p-try": "^2.0.0"
@@ -12706,8 +12372,7 @@
 						},
 						"p-locate": {
 							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-							"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+							"bundled": true,
 							"dev": true,
 							"requires": {
 								"p-limit": "^2.0.0"
@@ -12715,14 +12380,12 @@
 						},
 						"p-try": {
 							"version": "2.2.0",
-							"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-							"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+							"bundled": true,
 							"dev": true
 						},
 						"string-width": {
 							"version": "3.1.0",
-							"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-							"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+							"bundled": true,
 							"dev": true,
 							"requires": {
 								"emoji-regex": "^7.0.1",
@@ -12732,8 +12395,7 @@
 						},
 						"strip-ansi": {
 							"version": "5.2.0",
-							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-							"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+							"bundled": true,
 							"dev": true,
 							"requires": {
 								"ansi-regex": "^4.1.0"
@@ -12743,8 +12405,7 @@
 				},
 				"yargs-parser": {
 					"version": "15.0.1",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.1.tgz",
-					"integrity": "sha512-0OAMV2mAZQrs3FkNpDQcBk1x5HXb8X4twADss4S0Iuk+2dGnLOE/fRHrsYm542GduMveyA77OF4wrNJuanRCWw==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"camelcase": "^5.0.0",
@@ -12753,8 +12414,7 @@
 					"dependencies": {
 						"camelcase": {
 							"version": "5.3.1",
-							"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-							"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+							"bundled": true,
 							"dev": true
 						}
 					}
@@ -12897,16 +12557,6 @@
 				"prelude-ls": "~1.1.2",
 				"type-check": "~0.3.2",
 				"word-wrap": "~1.2.3"
-			}
-		},
-		"os-name": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/os-name/-/os-name-3.1.0.tgz",
-			"integrity": "sha512-h8L+8aNjNcMpo/mAIBPn5PXCM16iyPGjHNWo6U1YO8sJTMHtEtyczI6QJnLoplswm6goopQkqc7OAnjhWcugVg==",
-			"dev": true,
-			"requires": {
-				"macos-release": "^2.2.0",
-				"windows-release": "^3.1.0"
 			}
 		},
 		"os-tmpdir": {
@@ -13352,9 +13002,9 @@
 			"dev": true
 		},
 		"registry-auth-token": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-4.2.0.tgz",
-			"integrity": "sha512-P+lWzPrsgfN+UEpDS3U8AQKg/UjZX6mQSJueZj3EK+vNESoqBSpBUD3gmu4sF9lOsjXWjF11dQKUqemf3veq1w==",
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-4.2.1.tgz",
+			"integrity": "sha512-6gkSb4U6aWJB4SF2ZvLb76yCBjcvufXBqvvEx1HbmKPkutswjW1xNVRY0+daljIYRbogN7O0etYSlbiaEQyMyw==",
 			"dev": true,
 			"requires": {
 				"rc": "^1.2.8"
@@ -13576,9 +13226,9 @@
 			}
 		},
 		"run-parallel": {
-			"version": "1.1.9",
-			"resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.9.tgz",
-			"integrity": "sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q==",
+			"version": "1.1.10",
+			"resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.10.tgz",
+			"integrity": "sha512-zb/1OuZ6flOlH6tQyMPUrE3x3Ulxjlo9WIVXR4yVYi4H9UXQaeIsPbLn2R3O3vQCnDKkAl2qHiuocKKX4Tz/Sw==",
 			"dev": true
 		},
 		"rxjs": {
@@ -13761,9 +13411,9 @@
 			}
 		},
 		"semantic-release": {
-			"version": "17.1.1",
-			"resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-17.1.1.tgz",
-			"integrity": "sha512-9H+207eynBJElrQBHySZm+sIEoJeUhPA2zU4cdlY1QSInd2lnE8GRD2ALry9EassE22c9WW+aCREwBhro5AIIg==",
+			"version": "17.3.0",
+			"resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-17.3.0.tgz",
+			"integrity": "sha512-enhDayMZRP4nWcWAMBFHHB7THRaIcRdUAZv3lxd65pXs2ttzay7IeCvRRrGayRWExtnY0ulwRz5Ycp88Dv/UeQ==",
 			"dev": true,
 			"requires": {
 				"@semantic-release/commit-analyzer": "^8.0.0",
@@ -13808,18 +13458,18 @@
 					}
 				},
 				"debug": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"version": "4.3.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+					"integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
 					"dev": true,
 					"requires": {
-						"ms": "^2.1.1"
+						"ms": "2.1.2"
 					}
 				},
 				"execa": {
-					"version": "4.0.3",
-					"resolved": "https://registry.npmjs.org/execa/-/execa-4.0.3.tgz",
-					"integrity": "sha512-WFDXGHckXPWZX19t1kCsXzOpqX9LWYNqn4C+HqZlk/V0imTkzJZqf87ZBhvpHaftERYknpk0fjSylnXVlVgI0A==",
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
+					"integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
 					"dev": true,
 					"requires": {
 						"cross-spawn": "^7.0.0",
@@ -13844,18 +13494,18 @@
 					}
 				},
 				"get-stream": {
-					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
-					"integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+					"integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
 					"dev": true,
 					"requires": {
 						"pump": "^3.0.0"
 					}
 				},
 				"hosted-git-info": {
-					"version": "3.0.5",
-					"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-3.0.5.tgz",
-					"integrity": "sha512-i4dpK6xj9BIpVOTboXIlKG9+8HMKggcrMX7WA24xZtKwX0TPelq/rbaS5rCKeNX8sJXZJGdSxpnEGtta+wismQ==",
+					"version": "3.0.7",
+					"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-3.0.7.tgz",
+					"integrity": "sha512-fWqc0IcuXs+BmE9orLDyVykAG9GJtGLGuZAAqgcckPgv5xad4AcXGIv8galtQvlwutxSlaMcdw7BUtq2EIvqCQ==",
 					"dev": true,
 					"requires": {
 						"lru-cache": "^6.0.0"
@@ -13877,9 +13527,9 @@
 					}
 				},
 				"marked": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/marked/-/marked-1.1.1.tgz",
-					"integrity": "sha512-mJzT8D2yPxoPh7h0UXkB+dBj4FykPJ2OIfxAWeIHrvoHDkFxukV/29QxoFQoPM6RLEwhIFdJpmKBlqVM3s2ZIw==",
+					"version": "1.2.5",
+					"resolved": "https://registry.npmjs.org/marked/-/marked-1.2.5.tgz",
+					"integrity": "sha512-2AlqgYnVPOc9WDyWu7S5DJaEZsfk6dNh/neatQ3IHUW4QLutM/VPSH9lG7bif+XjFWc9K9XR3QvR+fXuECmfdA==",
 					"dev": true
 				},
 				"ms": {
@@ -13922,14 +13572,14 @@
 					"dev": true
 				},
 				"parse-json": {
-					"version": "5.0.1",
-					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.1.tgz",
-					"integrity": "sha512-ztoZ4/DYeXQq4E21v169sC8qWINGpcosGv9XhTDvg9/hWvx/zrFkc9BiWxR58OJLHGk28j5BL0SDLeV2WmFZlQ==",
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.1.0.tgz",
+					"integrity": "sha512-+mi/lmVVNKFNVyLXV31ERiy2CY5E1/F6QtJFEzoChPRwwngMNXRDQ9GJ5WdE2Z2P4AujsOi0/+2qHID68KwfIQ==",
 					"dev": true,
 					"requires": {
 						"@babel/code-frame": "^7.0.0",
 						"error-ex": "^1.3.1",
-						"json-parse-better-errors": "^1.0.1",
+						"json-parse-even-better-errors": "^2.3.0",
 						"lines-and-columns": "^1.1.6"
 					}
 				},
@@ -13983,10 +13633,13 @@
 					"dev": true
 				},
 				"semver": {
-					"version": "7.3.2",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
-					"integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
-					"dev": true
+					"version": "7.3.4",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
+					"integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+					"dev": true,
+					"requires": {
+						"lru-cache": "^6.0.0"
+					}
 				},
 				"shebang-command": {
 					"version": "2.0.0",
@@ -14696,14 +14349,15 @@
 			"dev": true
 		},
 		"tempy": {
-			"version": "0.5.0",
-			"resolved": "https://registry.npmjs.org/tempy/-/tempy-0.5.0.tgz",
-			"integrity": "sha512-VEY96x7gbIRfsxqsafy2l5yVxxp3PhwAGoWMyC2D2Zt5DmEv+2tGiPOrquNRpf21hhGnKLVEsuqleqiZmKG/qw==",
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/tempy/-/tempy-1.0.0.tgz",
+			"integrity": "sha512-eLXG5B1G0mRPHmgH2WydPl5v4jH35qEn3y/rA/aahKhIa91Pn119SsU7n7v/433gtT9ONzC8ISvNHIh2JSTm0w==",
 			"dev": true,
 			"requires": {
+				"del": "^6.0.0",
 				"is-stream": "^2.0.0",
 				"temp-dir": "^2.0.0",
-				"type-fest": "^0.12.0",
+				"type-fest": "^0.16.0",
 				"unique-string": "^2.0.0"
 			},
 			"dependencies": {
@@ -14714,9 +14368,9 @@
 					"dev": true
 				},
 				"type-fest": {
-					"version": "0.12.0",
-					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.12.0.tgz",
-					"integrity": "sha512-53RyidyjvkGpnWPMF9bQgFtWp+Sl8O2Rp13VavmJgfAP9WWG6q6TkrKU8iyJdnwnfgHI6k2hTlgqH4aSdjoTbg==",
+					"version": "0.16.0",
+					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.16.0.tgz",
+					"integrity": "sha512-eaBzG6MxNzEn9kiwvtre90cXaNLkmadMWa1zQMs3XORCXNbsH/OewwbxC5ia9dCxIxnTAsSxXJaa/p5y8DlvJg==",
 					"dev": true
 				}
 			}
@@ -14767,13 +14421,25 @@
 			"dev": true
 		},
 		"through2": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/through2/-/through2-3.0.2.tgz",
-			"integrity": "sha512-enaDQ4MUyP2W6ZyT6EsMzqBPZaM/avg8iuo+l2d3QCs0J+6RaqkHV/2/lOwDTueBHeJ/2LG9lrLW3d5rWPucuQ==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/through2/-/through2-4.0.2.tgz",
+			"integrity": "sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==",
 			"dev": true,
 			"requires": {
-				"inherits": "^2.0.4",
-				"readable-stream": "2 || 3"
+				"readable-stream": "3"
+			},
+			"dependencies": {
+				"readable-stream": {
+					"version": "3.6.0",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+					"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+					"dev": true,
+					"requires": {
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
+					}
+				}
 			}
 		},
 		"tmp": {
@@ -15130,13 +14796,10 @@
 			}
 		},
 		"universal-user-agent": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-5.0.0.tgz",
-			"integrity": "sha512-B5TPtzZleXyPrUMKCpEHFmVhMN6EhmJYjG5PQna9s7mXeSqGTLap4OpqLl5FCEFUI3UBmllkETwKf/db66Y54Q==",
-			"dev": true,
-			"requires": {
-				"os-name": "^3.1.0"
-			}
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
+			"integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w==",
+			"dev": true
 		},
 		"universalify": {
 			"version": "0.1.2",
@@ -15342,15 +15005,6 @@
 			"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
 			"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
 			"dev": true
-		},
-		"windows-release": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/windows-release/-/windows-release-3.3.1.tgz",
-			"integrity": "sha512-Pngk/RDCaI/DkuHPlGTdIkDiTAnAkyMjoQMZqRsxydNl1qGXNIoZrB7RK8g53F2tEgQBMqQJHQdYZuQEEAu54A==",
-			"dev": true,
-			"requires": {
-				"execa": "^1.0.0"
-			}
 		},
 		"word-wrap": {
 			"version": "1.2.3",

--- a/package.json
+++ b/package.json
@@ -44,14 +44,14 @@
 		"jest": "^26.4.2",
 		"node": "^12.13.0",
 		"prettier": "^2.0.4",
-		"semantic-release": "^17.1.1",
+		"semantic-release": "^17.3.0",
 		"ts-jest": "^26.3.0",
 		"typedoc": "^0.17.4",
 		"typescript": "^3.8.3"
 	},
 	"scripts": {
-		"format": "eslint --ext .ts src test .eslintrc.js --ignore-pattern '!.eslintrc.js' --fix",
-		"lint": "eslint --ext .ts src test .eslintrc.js --ignore-pattern '!.eslintrc.js'",
+		"format": "eslint --ext .ts src test --fix",
+		"lint": "eslint --ext .ts src test",
 		"test": "jest",
 		"test-coverage": "jest --coverage",
 		"clean": "rm -rf dist && rm -f tsconfig.tsbuildinfo",

--- a/src/endpoint/devices.ts
+++ b/src/endpoint/devices.ts
@@ -561,8 +561,8 @@ export class DevicesEndpoint extends Endpoint {
 	 * @param id
 	 * @param deviceEvents
 	 */
-	public sendEvents(id: string, deviceEvents: DeviceEventList): void {
-		this.client.post(`${id}/events`, deviceEvents)
+	public async sendEvents(id: string, deviceEvents: DeviceEventList): Promise<void> {
+		await this.client.post(`${id}/events`, deviceEvents)
 	}
 
 	/**

--- a/tsconfig-test.json
+++ b/tsconfig-test.json
@@ -9,10 +9,9 @@
 		"noImplicitReturns": true,
 		"noFallthroughCasesInSwitch": true,
 		"declarationMap": true,
-		"outDir": "./dist",
+		"outDir": "./dist_test",
 	},
 	"include": [
-		"./global.d.ts",
-		"./src/**/*.ts",
+		"./test/**/*.ts",
 	],
 }


### PR DESCRIPTION
* ran `npm audit fix`
* enabled `@typescript-eslint/no-floating-promises` rule, updating necessary configuration to allow this
* don't validate .eslint config file itself...this is apparently  not normal and was making it difficult to enable the configuration necessary to enable this rule
* fixed one error found by rule; this changes the return type of a method from `void` to `Promise<void>`--I'm not sure if this would be a breaking change or not
* fixed path for source files in tsconfig.json which exposed a warning in one of the files related to importing a module (http-signature) which has not TypeScript definitions
* added global.d.ts file to get TypeScript to ignore missing definitions for http-signature