### PR TITLE
fix: Added missing second parameter to presentation.get()

### DIFF
--- a/src/endpoint/presentation.ts
+++ b/src/endpoint/presentation.ts
@@ -200,8 +200,17 @@ export class PresentationEndpoint extends Endpoint {
 		return this.client.get<PresentationDeviceConfig>(`types/${profileId}/deviceconfig`, extraParams)
 	}
 
-	public get(presentationId: string): Promise<PresentationDeviceConfig> {
-		return this.client.get<PresentationDeviceConfig>('deviceconfig', { presentationId })
+	/**
+	 * Get a device configuration
+	 * @param presentationId The id returned from the device config create operation
+	 * @param manufacturerName The manufacturer name, e.g. SmartThingsCommunity
+	 */
+	public get(presentationId: string, manufacturerName?: string): Promise<PresentationDeviceConfig> {
+		if (manufacturerName) {
+			return this.client.get<PresentationDeviceConfig>('deviceconfig', { presentationId, manufacturerName })
+		} else {
+			return this.client.get<PresentationDeviceConfig>('deviceconfig', { presentationId })
+		}
 	}
 
 	/**

--- a/test/unit/data/presentation/device-config.ts
+++ b/test/unit/data/presentation/device-config.ts
@@ -1,0 +1,125 @@
+import {
+	CapabilityPresentationOperator,
+	CapabilityVisibleCondition,
+	PatchItemOpEnum,
+	PresentationDeviceConfig,
+	PresentationDeviceConfigEntry,
+	PresentationDPInfo,
+} from '../../../../src'
+
+
+const data = {
+	'manufacturerName': 'Test Manufacturer',
+	'presentationId': 'd8469d5c-3ca2-4601-9f21-2b7a0ccd44a5',
+	'type': 'profile',
+	'dpInfo': [
+
+	] as PresentationDPInfo[],
+	'iconUrl': 'www.randomplace.com/icon.png',
+	'dashboard': {
+		'states': [
+			{
+				'component': 'component',
+				'capability': 'testCapability',
+				'version': 1,
+				'values': [
+					{ 'key': 'keyName' },
+				],
+				'patch': [
+					{'op': PatchItemOpEnum.REPLACE, 'path': '/0/main/1/value', 'value': 'New Value'},
+				],
+				'visibleCondition': {
+					'component': 'component',
+					'version': 1,
+					'value': 'valueName',
+					'operator': CapabilityPresentationOperator.GREATER_THAN_OR_EQUALS,
+					'operand': 'keyName',
+				} as CapabilityVisibleCondition,
+			},
+		],
+		'actions': [
+			{
+				'component': 'component',
+				'capability': 'testCapability',
+				'version': 1,
+				'values': [
+					{ 'key': 'keyName' },
+				],
+				'patch': [
+					{'op': PatchItemOpEnum.REPLACE, 'path': '/0/main/1/value', 'value': 'New Value'},
+				],
+				'visibleCondition': {
+					'component': 'component',
+					'version': 1,
+					'value': 'valueName',
+					'operator': CapabilityPresentationOperator.GREATER_THAN_OR_EQUALS,
+					'operand': 'keyName',
+				} as CapabilityVisibleCondition,
+			},
+		] as PresentationDeviceConfigEntry[],
+	},
+	'detailView': [
+		{
+			'component': 'component',
+			'capability': 'testCapability',
+			'version': 1,
+			'values': [
+				{ 'key': 'keyName' },
+			],
+			'patch': [
+				{'op': PatchItemOpEnum.REPLACE, 'path': '/0/main/1/value', 'value': 'New Value'},
+			],
+			'visibleCondition': {
+				'component': 'component',
+				'version': 1,
+				'value': 'valueName',
+				'operator': CapabilityPresentationOperator.GREATER_THAN_OR_EQUALS,
+				'operand': 'keyName',
+			} as CapabilityVisibleCondition,
+		},
+	] as PresentationDeviceConfigEntry[],
+	'automation': {
+		'conditions': [
+			{
+				'component': 'component',
+				'capability': 'testCapability',
+				'version': 1,
+				'values': [
+					{ 'key': 'keyName' },
+				],
+				'patch': [
+					{'op': PatchItemOpEnum.REPLACE, 'path': '/0/main/1/value', 'value': 'New Value'},
+				],
+				'visibleCondition': {
+					'component': 'component',
+					'version': 1,
+					'value': 'valueName',
+					'operator': CapabilityPresentationOperator.GREATER_THAN_OR_EQUALS,
+					'operand': 'keyName',
+				} as CapabilityVisibleCondition,
+			},
+		] as PresentationDeviceConfigEntry[],
+		'actions': [
+			{
+				'component': 'component',
+				'capability': 'testCapability',
+				'version': 1,
+				'values': [
+					{ 'key': 'keyName' },
+				],
+				'patch': [
+					{'op': PatchItemOpEnum.REPLACE, 'path': '/0/main/1/value', 'value': 'New Value'},
+				],
+				'visibleCondition': {
+					'component': 'component',
+					'version': 1,
+					'value': 'valueName',
+					'operator': CapabilityPresentationOperator.GREATER_THAN_OR_EQUALS,
+					'operand': 'keyName',
+				} as CapabilityVisibleCondition,
+			},
+		] as PresentationDeviceConfigEntry[],
+	},
+} as PresentationDeviceConfig
+
+export default data

--- a/test/unit/data/presentation/presentation.ts
+++ b/test/unit/data/presentation/presentation.ts
@@ -1,125 +1,94 @@
-import {
-	CapabilityPresentationOperator,
-	CapabilityVisibleCondition,
-	PatchItemOpEnum,
-	PresentationDeviceConfig,
-	PresentationDeviceConfigEntry,
-	PresentationDPInfo,
-} from '../../../../src'
-
-
 const data = {
-	'manufacturerName': 'Test Manufacturer',
-	'presentationId': 'd8469d5c-3ca2-4601-9f21-2b7a0ccd44a5',
-	'type': 'profile',
-	'dpInfo': [
-
-	] as PresentationDPInfo[],
-	'iconUrl': 'www.randomplace.com/icon.png',
+	'manufacturerName': 'SmartThingsCommunity',
+	'presentationId': 'dd8fee94-0896-327c-bcb7-330955289c6d',
+	'mnmn': 'SmartThingsCommunity',
+	'vid': 'dd8fee94-0896-327c-bcb7-330955289c6d',
 	'dashboard': {
 		'states': [
 			{
-				'component': 'component',
-				'capability': 'testCapability',
+				'label': '{{outputVoltage.value}} V',
+				'capability': 'detailmedia27985.outputVoltage',
 				'version': 1,
-				'values': [
-					{ 'key': 'keyName' },
+				'component': 'main',
+			},
+		],
+		'actions': [],
+		'basicPlus': [],
+	},
+	'detailView': [
+		{
+			'capability': 'detailmedia27985.outputVoltage',
+			'version': 1,
+			'label': 'Output Voltage (RMS)',
+			'displayType': 'slider',
+			'slider': {
+				'range': [
+					0,
+					240,
 				],
-				'patch': [
-					{'op': PatchItemOpEnum.REPLACE, 'path': '/0/main/1/value', 'value': 'New Value'},
-				],
-				'visibleCondition': {
-					'component': 'component',
-					'version': 1,
-					'value': 'valueName',
-					'operator': CapabilityPresentationOperator.GREATER_THAN_OR_EQUALS,
-					'operand': 'keyName',
-				} as CapabilityVisibleCondition,
+				'step': 1,
+				'unit': null,
+				'command': 'setOutputVoltage',
+				'value': 'outputVoltage.value',
+			},
+			'state': null,
+			'component': 'main',
+		},
+	],
+	'automation': {
+		'conditions': [
+			{
+				'capability': 'detailmedia27985.outputVoltage',
+				'version': 1,
+				'label': 'Output Voltage (RMS)',
+				'displayType': 'slider',
+				'slider': {
+					'range': [
+						0,
+						240,
+					],
+					'step': 1,
+					'unit': null,
+					'value': 'outputVoltage.value',
+				},
+				'exclusion': [],
+				'component': 'main',
 			},
 		],
 		'actions': [
 			{
-				'component': 'component',
-				'capability': 'testCapability',
+				'capability': 'detailmedia27985.outputVoltage',
 				'version': 1,
-				'values': [
-					{ 'key': 'keyName' },
-				],
-				'patch': [
-					{'op': PatchItemOpEnum.REPLACE, 'path': '/0/main/1/value', 'value': 'New Value'},
-				],
-				'visibleCondition': {
-					'component': 'component',
-					'version': 1,
-					'value': 'valueName',
-					'operator': CapabilityPresentationOperator.GREATER_THAN_OR_EQUALS,
-					'operand': 'keyName',
-				} as CapabilityVisibleCondition,
+				'label': 'Output Voltage (RMS)',
+				'displayType': 'slider',
+				'slider': {
+					'range': [
+						0,
+						240,
+					],
+					'step': 1,
+					'unit': null,
+					'command': 'setOutputVoltage',
+				},
+				'component': 'main',
+				'exclusion': [],
 			},
-		] as PresentationDeviceConfigEntry[],
+		],
 	},
-	'detailView': [
+	'dpInfo': [
 		{
-			'component': 'component',
-			'capability': 'testCapability',
-			'version': 1,
-			'values': [
-				{ 'key': 'keyName' },
-			],
-			'patch': [
-				{'op': PatchItemOpEnum.REPLACE, 'path': '/0/main/1/value', 'value': 'New Value'},
-			],
-			'visibleCondition': {
-				'component': 'component',
-				'version': 1,
-				'value': 'valueName',
-				'operator': CapabilityPresentationOperator.GREATER_THAN_OR_EQUALS,
-				'operand': 'keyName',
-			} as CapabilityVisibleCondition,
+			'os': 'ios',
+			'dpUri': 'plugin://com.samsung.ios.plugin.stplugin/assets/files/index.html',
 		},
-	] as PresentationDeviceConfigEntry[],
-	'automation': {
-		'conditions': [
-			{
-				'component': 'component',
-				'capability': 'testCapability',
-				'version': 1,
-				'values': [
-					{ 'key': 'keyName' },
-				],
-				'patch': [
-					{'op': PatchItemOpEnum.REPLACE, 'path': '/0/main/1/value', 'value': 'New Value'},
-				],
-				'visibleCondition': {
-					'component': 'component',
-					'version': 1,
-					'value': 'valueName',
-					'operator': CapabilityPresentationOperator.GREATER_THAN_OR_EQUALS,
-					'operand': 'keyName',
-				} as CapabilityVisibleCondition,
-			},
-		] as PresentationDeviceConfigEntry[],
-		'actions': [
-			{
-				'component': 'component',
-				'capability': 'testCapability',
-				'version': 1,
-				'values': [
-					{ 'key': 'keyName' },
-				],
-				'patch': [
-					{'op': PatchItemOpEnum.REPLACE, 'path': '/0/main/1/value', 'value': 'New Value'},
-				],
-				'visibleCondition': {
-					'component': 'component',
-					'version': 1,
-					'value': 'valueName',
-					'operator': CapabilityPresentationOperator.GREATER_THAN_OR_EQUALS,
-					'operand': 'keyName',
-				} as CapabilityVisibleCondition,
-			},
-		] as PresentationDeviceConfigEntry[],
-	},
-} as PresentationDeviceConfig
+		{
+			'os': 'android',
+			'dpUri': 'plugin://com.samsung.android.plugin.stplugin',
+		},
+		{
+			'os': 'web',
+			'dpUri': 'wwst://com.samsung.one.plugin.stplugin',
+		},
+	],
+}
 
 export default data

--- a/test/unit/presentation.test.ts
+++ b/test/unit/presentation.test.ts
@@ -1,7 +1,8 @@
 import axios from '../../__mocks__/axios'
 
-import { NoOpAuthenticator, SmartThingsClient, PresentationDeviceConfig } from '../../src'
-import presentationDeviceConfiguration from './data/presentation/presentation'
+import {NoOpAuthenticator, SmartThingsClient, PresentationDeviceConfig, PresentationDevicePresentation} from '../../src'
+import deviceConfig from './data/presentation/device-config'
+import presentation from './data/presentation/presentation'
 
 
 const authenticator = new NoOpAuthenticator()
@@ -30,41 +31,72 @@ describe('Presentation',  () => {
 	})
 
 	it('generate', async () => {
-		axios.request.mockImplementationOnce(() => Promise.resolve({status: 200, data: presentationDeviceConfiguration}))
+		axios.request.mockImplementationOnce(() => Promise.resolve({status: 200, data: deviceConfig}))
 		const response: PresentationDeviceConfig = await client.presentation.generate(profileId)
 
 		expect(axios.request).toHaveBeenCalledTimes(1)
 		expect(axios.request).toHaveBeenCalledWith(expectedRequest(`presentation/types/${profileId}/deviceconfig`, undefined))
-		expect(response).toBe(presentationDeviceConfiguration)
+		expect(response).toBe(deviceConfig)
 	})
 
 	it('generate with optional params', async () => {
-		axios.request.mockImplementationOnce(() => Promise.resolve({status: 200, data: presentationDeviceConfiguration}))
+		axios.request.mockImplementationOnce(() => Promise.resolve({status: 200, data: deviceConfig}))
 		const response: PresentationDeviceConfig = await client.presentation.generate(profileId,
 			{ typeIntegration: 'dth' })
 
 		expect(axios.request).toHaveBeenCalledTimes(1)
 		expect(axios.request).toHaveBeenCalledWith(expectedRequest(`presentation/types/${profileId}/deviceconfig`,
 			{ typeIntegration: 'dth' }))
-		expect(response).toBe(presentationDeviceConfiguration)
+		expect(response).toBe(deviceConfig)
 	})
 
-	it('get', async () => {
-		axios.request.mockImplementationOnce(() => Promise.resolve({status: 200, data: presentationDeviceConfiguration}))
+	it('get config', async () => {
+		axios.request.mockImplementationOnce(() => Promise.resolve({status: 200, data: deviceConfig}))
 		const response: PresentationDeviceConfig = await client.presentation.get('d8469d5c-3ca2-4601-9f21-2b7a0ccd44a5')
 
 		expect(axios.request).toHaveBeenCalledTimes(1)
-		expect(axios.request).toHaveBeenCalledWith(expectedRequest('presentation/deviceconfig', { presentationId: 'd8469d5c-3ca2-4601-9f21-2b7a0ccd44a5' }))
-		expect(response).toBe(presentationDeviceConfiguration)
+		expect(axios.request).toHaveBeenCalledWith(expectedRequest('presentation/deviceconfig', {
+			presentationId: 'd8469d5c-3ca2-4601-9f21-2b7a0ccd44a5' }))
+		expect(response).toBe(deviceConfig)
+	})
+
+	it('get config with manufacturer', async () => {
+		axios.request.mockImplementationOnce(() => Promise.resolve({status: 200, data: deviceConfig}))
+		const response: PresentationDeviceConfig = await client.presentation.get('d8469d5c-3ca2-4601-9f21-2b7a0ccd44a5', 'aXyz1')
+
+		expect(axios.request).toHaveBeenCalledTimes(1)
+		expect(axios.request).toHaveBeenCalledWith(expectedRequest('presentation/deviceconfig', {
+			presentationId: 'd8469d5c-3ca2-4601-9f21-2b7a0ccd44a5', manufacturerName: 'aXyz1' }))
+		expect(response).toBe(deviceConfig)
+	})
+
+	it('get presentation', async () => {
+		axios.request.mockImplementationOnce(() => Promise.resolve({status: 200, data: presentation}))
+		const response: PresentationDevicePresentation = await client.presentation.getPresentation('d8469d5c-3ca2-4601-9f21-2b7a0ccd44a5')
+
+		expect(axios.request).toHaveBeenCalledTimes(1)
+		expect(axios.request).toHaveBeenCalledWith(expectedRequest('presentation', {
+			presentationId: 'd8469d5c-3ca2-4601-9f21-2b7a0ccd44a5' }))
+		expect(response).toBe(presentation)
+	})
+
+	it('get presentation with manufacturer', async () => {
+		axios.request.mockImplementationOnce(() => Promise.resolve({status: 200, data: presentation}))
+		const response: PresentationDevicePresentation = await client.presentation.getPresentation('d8469d5c-3ca2-4601-9f21-2b7a0ccd44a5', 'aXyz1')
+
+		expect(axios.request).toHaveBeenCalledTimes(1)
+		expect(axios.request).toHaveBeenCalledWith(expectedRequest('presentation', {
+			presentationId: 'd8469d5c-3ca2-4601-9f21-2b7a0ccd44a5', manufacturerName: 'aXyz1' }))
+		expect(response).toBe(presentation)
 	})
 
 	it('create', async () => {
-		axios.request.mockImplementationOnce(() => Promise.resolve({status: 200, data: presentationDeviceConfiguration}))
-		const response: PresentationDeviceConfig = await client.presentation.create(presentationDeviceConfiguration)
+		axios.request.mockImplementationOnce(() => Promise.resolve({status: 200, data: deviceConfig}))
+		const response: PresentationDeviceConfig = await client.presentation.create(deviceConfig)
 
 		expect(axios.request).toHaveBeenCalledTimes(1)
 		expect(axios.request).toHaveBeenCalledWith(expectedRequest('presentation/deviceconfig',
-			undefined, presentationDeviceConfiguration, 'post'))
-		expect(response).toBe(presentationDeviceConfiguration)
+			undefined, deviceConfig, 'post'))
+		expect(response).toBe(deviceConfig)
 	})
 })


### PR DESCRIPTION
Added missing manufacturerName parameter to the presentation endpoint's `get` method. Also added unit tests for the `getPresentation` method.