### PR TITLE
feat: Added device includeHealth and includeStatus options

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
 	},
 	"devDependencies": {
 		"@semantic-release/git": "^9.0.0",
-		"@types/es6-promise": "^3.3.0",
 		"@types/jest": "^26.0.10",
 		"@types/node": "^12.11.7",
 		"@types/qs": "^6.9.1",

--- a/src/endpoint-client.ts
+++ b/src/endpoint-client.ts
@@ -163,31 +163,31 @@ export class EndpointClient {
 		}
 	}
 
-	public async get<T = any, R = AxiosResponse<T>>(path?: string, params?: HttpClientParams): Promise<T> {
-		return this.request('get', path, undefined, params)
+	public async get<T = any, R = AxiosResponse<T>>(path?: string, params?: HttpClientParams, options?: EndpointClientRequestOptions<T>): Promise<T> {
+		return this.request('get', path, undefined, params, options)
 	}
 
-	public post<T = any, R = AxiosResponse<T>>(path?: string, data?: any, params?: HttpClientParams): Promise<T> {
-		return this.request('post', path, data, params)
+	public post<T = any, R = AxiosResponse<T>>(path?: string, data?: any, params?: HttpClientParams, options?: EndpointClientRequestOptions<T>): Promise<T> {
+		return this.request('post', path, data, params, options)
 	}
 
-	public put<T = any, R = AxiosResponse<T>>(path?: string, data?: any, params?: HttpClientParams): Promise<T> {
-		return this.request('put', path, data, params)
+	public put<T = any, R = AxiosResponse<T>>(path?: string, data?: any, params?: HttpClientParams, options?: EndpointClientRequestOptions<T>): Promise<T> {
+		return this.request('put', path, data, params, options)
 	}
 
-	public patch<T = any, R = AxiosResponse<T>>(path?: string, data?: any, params?: HttpClientParams): Promise<T> {
-		return this.request('patch', path, data, params)
+	public patch<T = any, R = AxiosResponse<T>>(path?: string, data?: any, params?: HttpClientParams, options?: EndpointClientRequestOptions<T>): Promise<T> {
+		return this.request('patch', path, data, params, options)
 	}
 
-	public delete<T = any, R = AxiosResponse<T>>(path?: string, params?: HttpClientParams): Promise<T> {
-		return this.request('delete', path, undefined, params)
+	public delete<T = any, R = AxiosResponse<T>>(path?: string, params?: HttpClientParams, options?: EndpointClientRequestOptions<T>): Promise<T> {
+		return this.request('delete', path, undefined, params, options)
 	}
 
-	public async getPagedItems<T = any, R = AxiosResponse<T>>(path?: string, params?: HttpClientParams): Promise<T[]> {
-		let list = await this.get<ItemsList>(path, params)
+	public async getPagedItems<T = any, R = AxiosResponse<T>>(path?: string, params?: HttpClientParams, options?: EndpointClientRequestOptions<ItemsList>): Promise<T[]> {
+		let list = await this.get<ItemsList>(path, params, options)
 		const result = list.items
 		while (list._links && list._links.next) {
-			list = await this.get<ItemsList>(list._links.next.href)
+			list = await this.get<ItemsList>(list._links.next.href, undefined, options)
 			result.push(...list.items)
 		}
 		return result

--- a/test/unit/data/devices/get_devices.ts
+++ b/test/unit/data/devices/get_devices.ts
@@ -3,7 +3,7 @@ const request = {
 	'method': 'get',
 	'headers': {
 		'Content-Type': 'application/json;charset=utf-8',
-		'Accept': 'application/json',
+		'Accept': 'application/vnd.smartthings+json;v=20170916',
 		'Authorization': 'Bearer 52991afa-66e8-4af0-8d85-5c568ed5ba7d',
 	},
 	'params': {},

--- a/test/unit/data/devices/get_devices_385931b6-0121-4848-bcc8-54cb76436de1.ts
+++ b/test/unit/data/devices/get_devices_385931b6-0121-4848-bcc8-54cb76436de1.ts
@@ -3,9 +3,10 @@ const request = {
 	'method': 'get',
 	'headers': {
 		'Content-Type': 'application/json;charset=utf-8',
-		'Accept': 'application/json',
+		'Accept': 'application/vnd.smartthings+json;v=20170916',
 		'Authorization': 'Bearer 52991afa-66e8-4af0-8d85-5c568ed5ba7d',
 	},
+	'params': {},
 }
 const response = {
 	'deviceId': '385931b6-0121-4848-bcc8-54cb76436de1',

--- a/test/unit/data/devices/get_devices_health_locationId=95efee9b-6073-4871-b5ba-de6642187293.ts
+++ b/test/unit/data/devices/get_devices_health_locationId=95efee9b-6073-4871-b5ba-de6642187293.ts
@@ -8,6 +8,7 @@ const request = {
 	},
 	'params': {
 		'locationId': '95efee9b-6073-4871-b5ba-de6642187293',
+		'includeHealth': 'true',
 	},
 }
 const response = {

--- a/test/unit/data/devices/get_devices_page_1_max_200.ts
+++ b/test/unit/data/devices/get_devices_page_1_max_200.ts
@@ -3,7 +3,7 @@ const request = {
 	'method': 'get',
 	'headers': {
 		'Content-Type': 'application/json;charset=utf-8',
-		'Accept': 'application/json',
+		'Accept': 'application/vnd.smartthings+json;v=20170916',
 		'Authorization': 'Bearer 52991afa-66e8-4af0-8d85-5c568ed5ba7d',
 	},
 }

--- a/test/unit/data/devices/get_devices_status_locationId=95efee9b-6073-4871-b5ba-de6642187293.ts
+++ b/test/unit/data/devices/get_devices_status_locationId=95efee9b-6073-4871-b5ba-de6642187293.ts
@@ -8,6 +8,7 @@ const request = {
 	},
 	'params': {
 		'locationId': '95efee9b-6073-4871-b5ba-de6642187293',
+		'includeStatus': 'true',
 	},
 }
 const response = {

--- a/test/unit/data/devices/list_devices_by_isa.ts
+++ b/test/unit/data/devices/list_devices_by_isa.ts
@@ -3,7 +3,7 @@ const request = {
 	'method': 'get',
 	'headers': {
 		'Content-Type': 'application/json;charset=utf-8',
-		'Accept': 'application/json',
+		'Accept': 'application/vnd.smartthings+json;v=20170916',
 		'Authorization': 'Bearer 52991afa-66e8-4af0-8d85-5c568ed5ba7d',
 	},
 	'params': {'installedAppId': 'f2b6aff2-832b-4d00-8d31-04b16d8f37c7'},

--- a/test/unit/data/devices/list_devices_by_type.ts
+++ b/test/unit/data/devices/list_devices_by_type.ts
@@ -3,7 +3,7 @@ const request = {
 	method: 'get',
 	headers: {
 		'Content-Type': 'application/json;charset=utf-8',
-		Accept: 'application/json',
+		Accept: 'application/vnd.smartthings+json;v=20170916',
 		Authorization: 'Bearer 52991afa-66e8-4af0-8d85-5c568ed5ba7d',
 	},
 	params: { type: 'HUB' },

--- a/test/unit/devices.test.ts
+++ b/test/unit/devices.test.ts
@@ -11,6 +11,8 @@ import {expectedRequest} from './helpers/utils'
 import listPage1 from './data/devices/get_devices'
 import listPage2 from './data/devices/get_devices_page_1_max_200'
 import locationList from './data/devices/get_devices_locationId=95efee9b-6073-4871-b5ba-de6642187293'
+import healthLocationList from './data/devices/get_devices_health_locationId=95efee9b-6073-4871-b5ba-de6642187293'
+import statusLocationList from './data/devices/get_devices_status_locationId=95efee9b-6073-4871-b5ba-de6642187293'
 import get from './data/devices/get_devices_385931b6-0121-4848-bcc8-54cb76436de1'
 import getStatus from './data/devices/get_devices_385931b6-0121-4848-bcc8-54cb76436de1_status'
 import getCapabilityStatus from './data/devices/get_devices_385931b6-0121-4848-bcc8-54cb76436de1_components_main_capabilities_colorTemperature_status'
@@ -72,6 +74,20 @@ describe('Devices',  () => {
 		const response: Device[] = await isaClient.devices.list()
 		expect(axios.request).toHaveBeenCalledWith(expectedRequest(locationList.request))
 		expect(response).toBe(locationList.response.items)
+	})
+
+	it('list with health', async () => {
+		axios.request.mockImplementationOnce(() => Promise.resolve({ status: 200, data: healthLocationList.response}))
+		const response: Device[] = await isaClient.devices.list({includeHealth: true})
+		expect(axios.request).toHaveBeenCalledWith(expectedRequest(healthLocationList.request))
+		expect(response).toBe(healthLocationList.response.items)
+	})
+
+	it('list with status', async () => {
+		axios.request.mockImplementationOnce(() => Promise.resolve({ status: 200, data: statusLocationList.response}))
+		const response: Device[] = await isaClient.devices.list({includeStatus: true})
+		expect(axios.request).toHaveBeenCalledWith(expectedRequest(statusLocationList.request))
+		expect(response).toBe(statusLocationList.response.items)
 	})
 
 	it('list for an implicit location 2', async () => {


### PR DESCRIPTION
Added the includeHealth and includeStatus options for the devices list and get methods. These are currently supported in the proper API version and save a lot of API calls in many common scenarios. Also updated the client get, put, post, etc. methods to accept headers, rather than forcing the endpoint to have to drop back to _request_. 