### PR TITLE
feat: Added endpoint to regenerate schema oauth credentials

### DIFF
--- a/src/endpoint/schema.ts
+++ b/src/endpoint/schema.ts
@@ -257,6 +257,15 @@ export class SchemaEndpoint extends Endpoint {
 	}
 
 	/**
+	 * Re-generate the OAuth clientId and clientSecret for an ST Schema connector. The old clientId and clientSecret
+	 * will no longer be valid after this operation.
+	 * @param id the "endpointApp" UUID of the connector, e.g. "viper_799ff3a0-8249-11e9-9bf1-b5c7d651c2c3"
+	 */
+	public regenerateOauth(id: string): Promise<SchemaCreateResponse> {
+		return this.client.post<SchemaCreateResponse>('oauth/stclient/credentials', {endpointAppId: id})
+	}
+
+	/**
 	 * Delete an ST Schema connector
 	 * @param id the "endpointApp" UUID of the connector, e.g. "viper_799ff3a0-8249-11e9-9bf1-b5c7d651c2c3"
 	 */

--- a/test/unit/data/schema/post.ts
+++ b/test/unit/data/schema/post.ts
@@ -27,3 +27,23 @@ export const post_schema_apps = {
 		'stClientSecret': '51d713160873792a7ceacda72125128abea8965b0c18176304371396e2d76fbf565402c66845c33a32fdaf912a44aa9fffc50c4186961229ca3a3f6f3fc75a8ccd27bba72a69ec66028d985fb8111bfce9e4bbcf67cda6310eb7414e4ddac3ebb2a0052890d3ed8a543c094832ccbfe3bdde53a428a5709a0efdd8a25c15312a7307860d97cf216e3e0433dff99f7babc9ada40266ba35172c05ffc505f1fc11cf8c2e41d5b2c13668bc1013029b8885138b8ffa5ef16dcce3cb81efe2cdf9db092d06511bc0ff7ab41af5d42f6483723938487bff15ef3efe9adec21201fcddcb434472cbf71249ae43f5cd9d053a2d598ce00efc7727301729b12575629844',
 	},
 }
+
+export const post_oauth_update = {
+	'request': {
+		'url': 'https://api.smartthings.com/schema/oauth/stclient/credentials',
+		'method': 'post',
+		'headers': {
+			'Content-Type': 'application/json;charset=utf-8',
+			'Accept': 'application/json',
+			'Authorization': 'Bearer 00000000-0000-0000-0000-000000000000',
+		},
+		'data': {
+			'endpointAppId': 'viper_9e767550-5f2a-11ea-9ea0-bb3ce8866e53',
+		},
+	},
+	'response': {
+		'endpointAppId': 'viper_9e767550-5f2a-11ea-9ea0-bb3ce8866e53',
+		'stClientId': 'aabdc28c-7f72-4380-a419-aeb52b27e0b4',
+		'stClientSecret': '51d713160873792a7ceacda72125128abea8965b0c18176304371396e2d76fbf565402c66845c33a32fdaf912a44aa9fffc50c4186961229ca3a3f6f3fc75a8ccd27bba72a69ec66028d985fb8111bfce9e4bbcf67cda6310eb7414e4ddac3ebb2a0052890d3ed8a543c094832ccbfe3bdde53a428a5709a0efdd8a25c15312a7307860d97cf216e3e0433dff99f7babc9ada40266ba35172c05ffc505f1fc11cf8c2e41d5b2c13668bc1013029b8885138b8ffa5ef16dcce3cb81efe2cdf9db092d06511bc0ff7ab41af5d42f6483723938487bff15ef3efe9adec21201fcddcb434472cbf71249ae43f5cd9d053a2d598ce00efc7727301729b12575629844',
+	},
+}

--- a/test/unit/schema.test.ts
+++ b/test/unit/schema.test.ts
@@ -17,6 +17,7 @@ import {
 } from './data/schema/get'
 import {
 	post_schema_apps as create,
+	post_oauth_update as updateOauth,
 } from './data/schema/post'
 import {
 	put_schema_apps_viper_9e767550_5f2a_11ea_9ea0_bb3ce8866e53 as update,
@@ -79,6 +80,13 @@ describe('Schema', () => {
 		})
 		expect(axios.request).toHaveBeenCalledWith(expectedRequest(update.request))
 		expect(response).toEqual(SuccessStatusValue)
+	})
+
+	it('Regenerate OAuth', async () => {
+		axios.request.mockImplementationOnce(() => Promise.resolve({ status: 200, data: updateOauth.response }))
+		const response: SchemaApp = await client.schema.regenerateOauth('viper_9e767550-5f2a-11ea-9ea0-bb3ce8866e53')
+		expect(axios.request).toHaveBeenCalledWith(expectedRequest(updateOauth.request))
+		expect(response).toEqual(updateOauth.response)
 	})
 
 	it('Get authorized page', async () => {


### PR DESCRIPTION
Added endpoint to regenerate OAuth clientId and clientSecret for ST Schema apps

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **[CONTRIBUTING](../CONTRIBUTING.md)** document
- [x] My code follows the code style of this project (`npm run lint` produces no warnings/errors)
- [x] Any required documentation has been added
- [x] I have added tests to cover my changes
