### PR TITLE
feat: Added method for cloning client with different headers

### DIFF
--- a/src/endpoint/organizations.ts
+++ b/src/endpoint/organizations.ts
@@ -4,7 +4,7 @@ import { EndpointClient, EndpointClientConfig } from '../endpoint-client'
 
 export interface OrganizationUpdateRequest {
 	label?: string
-	warehouseGroupId: string
+	warehouseGroupId?: string
 }
 
 export interface OrganizationCreateRequest extends OrganizationUpdateRequest {

--- a/src/st-client.ts
+++ b/src/st-client.ts
@@ -21,7 +21,7 @@ import { SubscriptionsEndpoint } from './endpoint/subscriptions'
 import { SchedulesEndpoint } from './endpoint/schedules'
 import { SchemaEndpoint } from './endpoint/schema'
 import { ServicesEndpoint } from './endpoint/services'
-import { SmartThingsURLProvider, defaultSmartThingsURLProvider } from './endpoint-client'
+import { SmartThingsURLProvider, defaultSmartThingsURLProvider, HttpClientHeaders } from './endpoint-client'
 
 
 export class SmartThingsClient extends RESTClient {
@@ -72,6 +72,10 @@ export class SmartThingsClient extends RESTClient {
 	public setLocation(id: string): SmartThingsClient {
 		this.config.locationId = id
 		return this
+	}
+
+	public clone(headers?: HttpClientHeaders): SmartThingsClient {
+		return new SmartThingsClient(this.config.authenticator, {...this.config, headers})
 	}
 }
 

--- a/test/unit/st-client.test.ts
+++ b/test/unit/st-client.test.ts
@@ -1,0 +1,51 @@
+import axios from '../../__mocks__/axios'
+import {
+	BearerTokenAuthenticator,
+	SmartThingsClient,
+} from '../../src'
+
+
+describe('ST Client', () => {
+	afterEach(() => {
+		axios.request.mockReset()
+	})
+
+	it('Construction with no location', async () => {
+		const client = new SmartThingsClient(
+			new BearerTokenAuthenticator('00000000-0000-0000-0000-000000000000'))
+		expect(client.config.locationId).toBeUndefined()
+	})
+
+	it('Construction with location ID', async () => {
+		const client = new SmartThingsClient(
+			new BearerTokenAuthenticator('00000000-0000-0000-0000-000000000000'),
+			{ locationId: '95efee9b-6073-4871-b5ba-de6642187293' })
+		expect(client.config.locationId).toBe('95efee9b-6073-4871-b5ba-de6642187293')
+	})
+
+	it('Construction with setLocation', async () => {
+		const client = new SmartThingsClient(
+			new BearerTokenAuthenticator('00000000-0000-0000-0000-000000000000'))
+		client.setLocation('d52f4bd1-700b-4730-a05a-e1fbe999ee8d')
+		expect(client.config.locationId).toBe('d52f4bd1-700b-4730-a05a-e1fbe999ee8d')
+	})
+
+	it('Clone with new headers', async () => {
+		const client = new SmartThingsClient(
+			new BearerTokenAuthenticator('00000000-0000-0000-0000-000000000000'))
+
+		const client2 = client.clone({'X-ST-Organization': 'e639ddd9-8af4-4725-a491-eda77c41dc7b'})
+
+		expect(client.config.headers).toBeDefined()
+		if (client.config.headers) {
+			expect(client.config.headers['X-ST-Organization']).toBeUndefined()
+		}
+
+		expect(client2.config.headers).toBeDefined()
+		if (client2.config.headers) {
+			expect(client2.config.headers['X-ST-Organization']).toBe('e639ddd9-8af4-4725-a491-eda77c41dc7b')
+		}
+
+	})
+
+})


### PR DESCRIPTION
Added method to clone a client with a different set of headers. Necessary so that one CLI command can call methods
on behalf of different organizations

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **[CONTRIBUTING](../CONTRIBUTING.md)** document
- [x] My code follows the code style of this project (`npm run lint` produces no warnings/errors)
- [ ] Any required documentation has been added
- [x] I have added tests to cover my changes
