### PR TITLE
feat: add support for logging RFC 2068 warning headers

### DIFF
--- a/src/endpoint/deviceprofiles.ts
+++ b/src/endpoint/deviceprofiles.ts
@@ -46,6 +46,9 @@ export interface DeviceProfilePreferenceRequest extends DeviceProfilePreferenceC
 }
 
 export interface DeviceProfileUpdateRequest {
+	/**
+	 * must have between 1 and 20 components
+	 */
 	components?: DeviceComponentRequest[]
 	metadata?: { [key: string]: string }
 	preferences?: DeviceProfilePreferenceRequest[]

--- a/src/rest-client.ts
+++ b/src/rest-client.ts
@@ -1,5 +1,6 @@
 import { Authenticator } from './authenticator'
-import { EndpointClientConfig, HttpClientHeaders, SmartThingsURLProvider, defaultSmartThingsURLProvider } from './endpoint-client'
+import { EndpointClientConfig, HttpClientHeaders, SmartThingsURLProvider,
+	defaultSmartThingsURLProvider, WarningFromHeader } from './endpoint-client'
 import { Logger } from './logger'
 
 
@@ -11,6 +12,7 @@ export interface RESTClientConfig {
 	urlProvider?: SmartThingsURLProvider
 	locationId?: string
 	installedAppId?: string
+	warningLogger?: (warnings: WarningFromHeader[] | string) => void | Promise<void>
 }
 
 


### PR DESCRIPTION
<!-- Describe your pull request. -->

* added a `warningLogger` config option that the CLI can use to log warning messages
* updated unit tests including adding tests for a couple of methods that were previously not unit-tested

Axios combines multiple headers into a single comma-separated string so I put code here to split them and parse the fields of each warning. If, for any reason, the string cannot be parsed it will simply be passed to the warning logger. I did this rather than throwing an exception because a badly formatted warning message or a bug in our parsing to break the CLI.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **[CONTRIBUTING](../CONTRIBUTING.md)** document
- [x] My code follows the code style of this project (`npm run lint` produces no warnings/errors)
- [x] Any required documentation has been added
- [x] I have added tests to cover my changes
