### PR TITLE
feat: add support for listing drivers in default channel

### DIFF
--- a/src/endpoint/drivers.ts
+++ b/src/endpoint/drivers.ts
@@ -214,6 +214,14 @@ export class DriversEndpoint extends Endpoint {
 	}
 
 	/**
+	 * List drivers in the default channel. (The default channel in this context is a channel
+	 * that users do not need to subscribe to.)
+	 */
+	public async listDefault(): Promise<EdgeDriverSummary[]> {
+		return this.client.getPagedItems('default')
+	}
+
+	/**
 	 * Uploads the zipped package represented by archiveData.
 	 */
 	public async upload(archiveData: Uint8Array): Promise<EdgeDriver> {

--- a/test/unit/drivers.test.ts
+++ b/test/unit/drivers.test.ts
@@ -50,6 +50,15 @@ describe('DriversEndpoint', () => {
 		expect(getPagedItemsSpy).toHaveBeenCalledWith('')
 	})
 
+	test('listDefault', async () => {
+		const drivers = [{ driverId: 'listed-in-channel-id' }] as EdgeDriverSummary[]
+		getPagedItemsSpy.mockResolvedValueOnce(drivers)
+
+		expect(await driversEndpoint.listDefault()).toBe(drivers)
+
+		expect(getPagedItemsSpy).toHaveBeenCalledWith('default')
+	})
+
 	test('upload', async () => {
 		const driver = { driverId: 'driver-id' }
 		requestSpy.mockResolvedValueOnce(driver)


### PR DESCRIPTION
<!-- Describe your pull request. -->

* Added support for new endpoint listing drivers in default channel (a channel users have access to without subscribing to it).

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **[CONTRIBUTING](../CONTRIBUTING.md)** document
- [x] My code follows the code style of this project (`npm run lint` produces no warnings/errors)
- [x] Any required documentation has been added
- [x] I have added tests to cover my changes
