### PR TITLE
fix: correct type of JSON schema v4 items property

### DIFF
--- a/src/endpoint/capabilities.ts
+++ b/src/endpoint/capabilities.ts
@@ -44,7 +44,7 @@ export interface CapabilityJSONSchema {
 	enum?: string[]
 	propertyName?: unknown
 	properties?: { [name: string]: CapabilityJSONSchema }
-	items?: CapabilityJSONSchema | [CapabilityJSONSchema]
+	items?: CapabilityJSONSchema | CapabilityJSONSchema[]
 	title?: string
 }
 


### PR DESCRIPTION
<!-- Describe your pull request. -->

Fixed the type of `items` for the `CapabilityJSONSchema` interface to allow arrays of any size per the spec.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **[CONTRIBUTING](../CONTRIBUTING.md)** document
- [x] My code follows the code style of this project (`npm run lint` produces no warnings/errors)
- [ ] Any required documentation has been added
- [ ] I have added tests to cover my changes
