### PR TITLE
fix: add support for including forceUpdate parameter when switching drivers

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,9 +1,11 @@
 {
 	"cSpell.words": [
+		"childdevice",
 		"commitlint",
 		"conventionalcommits",
 		"devicepreferences",
 		"deviceprofiles",
+		"Hubdevices",
 		"installedapps",
 		"PENGYOU",
 		"smartthingspi",

--- a/src/endpoint/hubdevices.ts
+++ b/src/endpoint/hubdevices.ts
@@ -62,8 +62,9 @@ export class HubdevicesEndpoint extends Endpoint {
 	/**
 	 * Change the driver for a device to the one specified by driverId.
 	 */
-	public async switchDriver(driverId: string, hubId: string, deviceId: string): Promise<void> {
-		return this.client.patch(`${hubId}/childdevice/${deviceId}`, { driverId })
+	public async switchDriver(driverId: string, hubId: string, deviceId: string, forceUpdate = false): Promise<void> {
+		return this.client.patch(`${hubId}/childdevice/${deviceId}`, { driverId },
+			forceUpdate ? { forceUpdate: 'true' } : undefined)
 	}
 
 	/**

--- a/test/unit/hubdevices.test.ts
+++ b/test/unit/hubdevices.test.ts
@@ -26,13 +26,28 @@ describe('HubdevicesEndpoint', () => {
 		expect(putSpy).toHaveBeenCalledWith('hub-id/drivers/driver-id', { channelId: 'channel-id' })
 	})
 
-	test('switchDriver', async () => {
-		patchSpy.mockImplementationOnce(() => Promise.resolve())
+	describe('switchDriver', () => {
+		it('calls patch with driver id', async () => {
+			patchSpy.mockImplementationOnce(() => Promise.resolve())
 
-		await expect(hubdevicesEndpoint.switchDriver('driver-id', 'hub-id', 'device-id')).resolves.not.toThrow()
+			await expect(hubdevicesEndpoint.switchDriver('driver-id', 'hub-id', 'device-id'))
+				.resolves.not.toThrow()
 
-		expect(patchSpy).toHaveBeenCalledTimes(1)
-		expect(patchSpy).toHaveBeenCalledWith('hub-id/childdevice/device-id', { driverId: 'driver-id' })
+			expect(patchSpy).toHaveBeenCalledTimes(1)
+			expect(patchSpy).toHaveBeenCalledWith('hub-id/childdevice/device-id',
+				{ driverId: 'driver-id' }, undefined)
+		})
+
+		it('includes forceUpdate query parameter when specified', async () => {
+			patchSpy.mockImplementationOnce(() => Promise.resolve())
+
+			await expect(hubdevicesEndpoint.switchDriver('driver-id', 'hub-id', 'device-id', true))
+				.resolves.not.toThrow()
+
+			expect(patchSpy).toHaveBeenCalledTimes(1)
+			expect(patchSpy).toHaveBeenCalledWith('hub-id/childdevice/device-id',
+				{ driverId: 'driver-id' }, { forceUpdate: 'true' })
+		})
 	})
 
 	test('uninstallDriver', async () => {


### PR DESCRIPTION
added support for including `forceUpdate` parameter when switching drivers

This is needed by the [CLI PR #427](https://github.com/SmartThingsCommunity/smartthings-cli/pull/427).

<!-- Describe your pull request. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **[CONTRIBUTING](../CONTRIBUTING.md)** document
- [x] My code follows the code style of this project (`npm run lint` produces no warnings/errors)
- [ ] Any required documentation has been added
- [x] I have added tests to cover my changes
