### PR TITLE
chore: clarify language about deleting subscriptions

### DIFF
--- a/src/endpoint/subscriptions.ts
+++ b/src/endpoint/subscriptions.ts
@@ -236,14 +236,14 @@ export class SubscriptionsEndpoint extends Endpoint {
 
 	/**
 	 * Deletes one or more subscriptions of an installed app
-	 * @param name name of the subscription to delete. If not specified then all subscriptions associated with the
+	 * @param subscriptionId UUID of the subscription to delete. If not specified then all subscriptions associated with the
 	 * installed app instance are deleted.
 	 * @param installedAppId UUID of the installed app. This parameter is not required if the client id configured
 	 * with an installedAppId
 	 */
-	public delete(name?: string, installedAppId?: string): Promise<Count> {
-		if (name) {
-			return this.client.delete<Count>(`${this.installedAppId(installedAppId)}/subscriptions/${name}`)
+	public delete(subscriptionId?: string, installedAppId?: string): Promise<Count> {
+		if (subscriptionId) {
+			return this.client.delete<Count>(`${this.installedAppId(installedAppId)}/subscriptions/${subscriptionId}`)
 		}
 		return this.client.delete<Count>(`${this.installedAppId(installedAppId)}/subscriptions`)
 	}


### PR DESCRIPTION
Change language in the `subscriptions.delete()` method to properly state that deletion of individual subscriptions requires a subscription UUID.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **[CONTRIBUTING](../CONTRIBUTING.md)** document
- [x] My code follows the code style of this project (`npm run lint` produces no warnings/errors)
- [x] Any required documentation has been added
- [ ] I have added tests to cover my changes
