### PR TITLE
fix: corrected type returned by default drivers command

### DIFF
--- a/.changeset/flat-deers-relate.md
+++ b/.changeset/flat-deers-relate.md
@@ -1,0 +1,5 @@
+---
+"@smartthings/core-sdk": patch
+---
+
+fix: corrected type returned by default drivers command

--- a/src/endpoint/drivers.ts
+++ b/src/endpoint/drivers.ts
@@ -219,7 +219,7 @@ export class DriversEndpoint extends Endpoint {
 	 * List drivers in the default channel. (The default channel in this context is a channel
 	 * that users do not need to subscribe to.)
 	 */
-	public async listDefault(): Promise<EdgeDriverSummary[]> {
+	public async listDefault(): Promise<EdgeDriver[]> {
 		return this.client.getPagedItems('default')
 	}
 

--- a/test/unit/drivers.test.ts
+++ b/test/unit/drivers.test.ts
@@ -1,5 +1,5 @@
 import { NoOpAuthenticator } from '../../src/authenticator'
-import { DriversEndpoint, EdgeDriverSummary } from '../../src/endpoint/drivers'
+import {DriversEndpoint, EdgeDriver, EdgeDriverSummary} from '../../src/endpoint/drivers'
 import { EndpointClient } from '../../src/endpoint-client'
 
 
@@ -51,7 +51,7 @@ describe('DriversEndpoint', () => {
 	})
 
 	test('listDefault', async () => {
-		const drivers = [{ driverId: 'listed-in-channel-id' }] as EdgeDriverSummary[]
+		const drivers = [{ driverId: 'listed-in-channel-id' }] as EdgeDriver[]
 		getPagedItemsSpy.mockResolvedValueOnce(drivers)
 
 		expect(await driversEndpoint.listDefault()).toBe(drivers)


### PR DESCRIPTION
Corrected the type returned by the edge drivers `listDefault()` command. It's the complete driver definition, not just the summary.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **[CONTRIBUTING](../CONTRIBUTING.md)** document
- [ ] My code follows the code style of this project (`npm run lint` produces no warnings/errors)
- [ ] Any required documentation has been added
- [ ] I have added tests to cover my changes
