### PR TITLE
Add ordered param to devices execute commands

### DIFF
--- a/src/endpoint-client.ts
+++ b/src/endpoint-client.ts
@@ -8,7 +8,7 @@ import { Logger, noLogLogger } from './logger'
 export interface HttpClientHeaders {
 	[name: string]: string
 }
-export type HttpClientParamValue = string | string[] | number
+export type HttpClientParamValue = string | string[] | number | boolean | undefined
 export interface HttpClientParams {
 	[name: string]: HttpClientParamValue
 }

--- a/src/endpoint/devices.ts
+++ b/src/endpoint/devices.ts
@@ -1187,9 +1187,10 @@ export class DevicesEndpoint extends Endpoint {
 	 * Sends the specified list of commands to the device
 	 * @param id UUID of the device
 	 * @param commands list of commands
+	 * @param ordered Specifies whether the command should be executed in order or asynchronously.
 	 */
-	public async executeCommands(id: string, commands: Command[]): Promise<CommandResponse> {
-		return this.client.post(`${id}/commands`, { commands })
+	public async executeCommands(id: string, commands: Command[], ordered?: boolean): Promise<CommandResponse> {
+		return this.client.post(`${id}/commands`, { commands }, { 'ordered': ordered })		
 	}
 
 	/**

--- a/test/unit/devices.test.ts
+++ b/test/unit/devices.test.ts
@@ -1,6 +1,8 @@
-import { CommandRequest, CommandList, Command, DeviceHealthState, DeviceProfileUpdate,
+import {
+	CommandRequest, CommandList, Command, DeviceHealthState, DeviceProfileUpdate,
 	DeviceUpdate, DevicesEndpoint, Device, DeviceEvent, DevicePreferenceResponse, DeviceCreate,
-	CommandResponse}  from '../../src/endpoint/devices'
+	CommandResponse,
+} from '../../src/endpoint/devices'
 import { ConfigEntry, ConfigValueType } from '../../src/endpoint/installedapps'
 import { BearerTokenAuthenticator } from '../../src/authenticator'
 import { EndpointClient } from '../../src/endpoint-client'
@@ -346,7 +348,25 @@ describe('DevicesEndpoint', () => {
 			expect(await devicesEndpoint.executeCommands('device-id', [command])).toBe(commandResponse)
 
 			expect(postSpy).toHaveBeenCalledTimes(1)
-			expect(postSpy).toHaveBeenCalledWith('device-id/commands', { commands: [command] })
+			expect(postSpy).toHaveBeenCalledWith('device-id/commands', { commands: [command] }, {'ordered': undefined})
+		})
+
+		it('works with true ordered param passed', async () => {
+			const command = { command: 'command-1' } as Command
+			postSpy.mockResolvedValueOnce(commandResponse)
+			expect(await devicesEndpoint.executeCommands('device-id', [command], true)).toBe(commandResponse)
+
+			expect(postSpy).toHaveBeenCalledTimes(1)
+			expect(postSpy).toHaveBeenCalledWith('device-id/commands', { commands: [command] }, { ordered: true })
+		})
+
+		it('works with false ordered param passed', async () => {
+			const command = { command: 'command-1' } as Command
+			postSpy.mockResolvedValueOnce(commandResponse)
+			expect(await devicesEndpoint.executeCommands('device-id', [command], false)).toBe(commandResponse)
+
+			expect(postSpy).toHaveBeenCalledTimes(1)
+			expect(postSpy).toHaveBeenCalledWith('device-id/commands', { commands: [command] }, {'ordered': false})
 		})
 
 		it('passes on exceptions', async () => {
@@ -357,7 +377,7 @@ describe('DevicesEndpoint', () => {
 			await expect(devicesEndpoint.executeCommands('device-id', [command])).rejects.toThrow(error)
 
 			expect(postSpy).toHaveBeenCalledTimes(1)
-			expect(postSpy).toHaveBeenCalledWith('device-id/commands', { commands: [command] })
+			expect(postSpy).toHaveBeenCalledWith('device-id/commands', { commands: [command] }, {'ordered': undefined})
 		})
 	})
 
@@ -385,7 +405,7 @@ describe('DevicesEndpoint', () => {
 	})
 
 	describe('sendCommand', () => {
-		it ('processes simple single command', async () => {
+		it('processes simple single command', async () => {
 			const deviceConfig = {
 				deviceId: 'device-id',
 				componentId: 'component-id',


### PR DESCRIPTION
This pull request addresses issue #217 

This pull request adds an ordered parameter to devices.executeCommands such that developers using this SDK can choose to set the ordered parameter for the {/commands} REST API endpoint

## Types of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **[CONTRIBUTING](../CONTRIBUTING.md)** document
- [x] My code follows the code style of this project (`npm run lint` produces no warnings/errors)
- [x] Any required documentation has been added
- [x] I have added tests to cover my changes
