### PR TITLE
fix: revert axios to CommonJS-only version

### DIFF
--- a/.changeset/five-sloths-cheer.md
+++ b/.changeset/five-sloths-cheer.md
@@ -1,0 +1,5 @@
+---
+"@smartthings/core-sdk": minor
+---
+
+go back to older version of axios; current version does not work with tools used in the SmartThings CLI

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
 			"license": "Apache-2.0",
 			"dependencies": {
 				"async-mutex": "^0.4.0",
-				"axios": "^1.5.0",
+				"axios": "^0.27.2",
 				"http-signature": "^1.3.6",
 				"lodash.isdate": "^4.0.1",
 				"lodash.isstring": "^4.0.1",
@@ -3051,13 +3051,12 @@
 			}
 		},
 		"node_modules/axios": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-1.5.0.tgz",
-			"integrity": "sha512-D4DdjDo5CY50Qms0qGQTTw6Q44jl7zRwY7bthds06pUGfChBCTcQs+N743eFWGEd6pRTMd6A+I87aWyFV5wiZQ==",
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+			"integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
 			"dependencies": {
-				"follow-redirects": "^1.15.0",
-				"form-data": "^4.0.0",
-				"proxy-from-env": "^1.1.0"
+				"follow-redirects": "^1.14.9",
+				"form-data": "^4.0.0"
 			}
 		},
 		"node_modules/babel-jest": {
@@ -7781,11 +7780,6 @@
 				"node": ">= 6"
 			}
 		},
-		"node_modules/proxy-from-env": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-			"integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
-		},
 		"node_modules/pseudomap": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
@@ -11915,13 +11909,12 @@
 			"dev": true
 		},
 		"axios": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-1.5.0.tgz",
-			"integrity": "sha512-D4DdjDo5CY50Qms0qGQTTw6Q44jl7zRwY7bthds06pUGfChBCTcQs+N743eFWGEd6pRTMd6A+I87aWyFV5wiZQ==",
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+			"integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
 			"requires": {
-				"follow-redirects": "^1.15.0",
-				"form-data": "^4.0.0",
-				"proxy-from-env": "^1.1.0"
+				"follow-redirects": "^1.14.9",
+				"form-data": "^4.0.0"
 			}
 		},
 		"babel-jest": {
@@ -15427,11 +15420,6 @@
 				"kleur": "^3.0.3",
 				"sisteransi": "^1.0.5"
 			}
-		},
-		"proxy-from-env": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-			"integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
 		},
 		"pseudomap": {
 			"version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
 	],
 	"dependencies": {
 		"async-mutex": "^0.4.0",
-		"axios": "^1.5.0",
+		"axios": "^0.27.2",
 		"http-signature": "^1.3.6",
 		"lodash.isdate": "^4.0.1",
 		"lodash.isstring": "^4.0.1",


### PR DESCRIPTION
<!-- Describe your pull request. -->

Revert axios to CommonJS-only version. The newer combined ESM/CommonJS version confuses the `pkg` tool used to build the CLI binary.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] I have read the **[CONTRIBUTING](../CONTRIBUTING.md)** document
- [x] My code follows the code style of this project (`npm run lint` produces no warnings/errors)
