### PR TITLE
fix: decouple axios version from core SDK

### DIFF
--- a/.changeset/friendly-turtles-kneel.md
+++ b/.changeset/friendly-turtles-kneel.md
@@ -1,0 +1,6 @@
+---
+"@smartthings/core-sdk": patch
+---
+
+Decouple from axios. Dependents of the core SDK no longer need to use the same version of
+axios, or even use axios at all.

--- a/test/unit/authenticator.test.ts
+++ b/test/unit/authenticator.test.ts
@@ -28,50 +28,24 @@ describe('authenticators', () => {
 		jest.clearAllMocks()
 	})
 
-	const config = { url: 'https://api.smartthings.com', headers: { Test: 'test' } }
+	test('NoOpAuthenticator returns no headers', async () => {
+		const authenticator = new NoOpAuthenticator()
 
-	describe('NoOpAuthenticator', () => {
-		test('authenticate returns config unchanged', async () => {
-			const authenticator = new NoOpAuthenticator()
-			const data = await authenticator.authenticate(config)
-
-			expect(data).toBe(config)
-		})
-
-		test('authenticateGeneric returns empty string for token', async () => {
-			const authenticator = new NoOpAuthenticator()
-			const token = await authenticator.authenticateGeneric()
-
-			expect(token).toBe('')
-		})
+		expect(await authenticator.authenticate()).toStrictEqual({})
 	})
 
-	describe('BearerTokenAuthenticator', () => {
-		test('authenticate adds header with specified token', async () => {
-			const authenticator = new BearerTokenAuthenticator('a-bearer-token')
-			const data = await authenticator.authenticate(config)
+	test('BearerTokenAuthenticator returns header with specified token', async () => {
+		const authenticator = new BearerTokenAuthenticator('a-bearer-token')
 
-			expect(data.url).toBe(config.url)
-			expect(data.headers?.Authorization).toBe('Bearer a-bearer-token')
-			expect(data.headers?.Test).toBe('test')
-		})
-
-		test('authenticateGeneric returns specified token', async () => {
-			const authenticator = new BearerTokenAuthenticator('a-bearer-token')
-			const token = await authenticator.authenticateGeneric()
-
-			expect(token).toBe('a-bearer-token')
-		})
+		expect(await authenticator.authenticate()).toStrictEqual({ Authorization: 'Bearer a-bearer-token' })
 	})
 
 	describe('RefreshTokenAuthenticator', () => {
-		test('authenticate adds header with specified token', async () => {
+		test('authenticate returns header with specified token', async () => {
 			const tokenStore = new TokenStore()
 			const authenticator = new RefreshTokenAuthenticator('a-refreshable-bearer-token', tokenStore)
-			const data = await authenticator.authenticate(config)
 
-			expect(data.url).toBe(config.url)
-			expect(data.headers?.Authorization).toBe('Bearer a-refreshable-bearer-token')
+			expect(await authenticator.authenticate()).toStrictEqual({ Authorization: 'Bearer a-refreshable-bearer-token' })
 		})
 
 		test('refresh updates token', async () => {
@@ -86,7 +60,8 @@ describe('authenticators', () => {
 			const tokenStore = new TokenStore()
 			const authenticator = new RefreshTokenAuthenticator('a-refreshable-bearer-token', tokenStore)
 			const endpointConfig = { urlProvider: defaultSmartThingsURLProvider, authenticator }
-			await authenticator.refresh(config, endpointConfig)
+
+			expect(await authenticator.refresh(endpointConfig)).toStrictEqual({ Authorization: 'Bearer the-access-token' })
 
 			expect(axios.request).toHaveBeenCalledTimes(1)
 			expect(axios.request).toHaveBeenCalledWith({
@@ -114,7 +89,7 @@ describe('authenticators', () => {
 			const endpointConfig = { urlProvider: defaultSmartThingsURLProvider, authenticator }
 			let message
 			try {
-				await authenticator.refresh(config, endpointConfig)
+				await authenticator.refresh(endpointConfig)
 			// eslint-disable-next-line @typescript-eslint/no-explicit-any
 			} catch (error: any) {
 				message = error.message
@@ -133,10 +108,7 @@ describe('authenticators', () => {
 		const authenticator = new SequentialRefreshTokenAuthenticator('a-bearer-token', tokenStore, mutex)
 
 		test('authenticate adds header with specified token', async () => {
-			const data = await authenticator.authenticate(config)
-
-			expect(data.url).toBe(config.url)
-			expect(data.headers?.Authorization).toBe('Bearer a-bearer-token')
+			expect(await authenticator.authenticate()).toStrictEqual({ Authorization: 'Bearer a-bearer-token' })
 		})
 
 		describe('refresh', () => {
@@ -151,7 +123,7 @@ describe('authenticators', () => {
 			const endpointConfig = { urlProvider: defaultSmartThingsURLProvider, authenticator }
 
 			it('updates token', async () => {
-				await authenticator.refresh(config, endpointConfig)
+				await authenticator.refresh(endpointConfig)
 
 				expect(axios.request).toHaveBeenCalledTimes(1)
 				expect(axios.request).toHaveBeenCalledWith({
@@ -169,8 +141,7 @@ describe('authenticators', () => {
 			})
 
 			it('works on request with no existing headers', async () => {
-				const configWithoutHeaders = { url: 'https://api.smartthings.com' }
-				await authenticator.refresh(configWithoutHeaders, endpointConfig)
+				expect(await authenticator.refresh(endpointConfig)).toStrictEqual({ Authorization: 'Bearer the-access-token' })
 
 				expect(axios.request).toHaveBeenCalledTimes(1)
 				expect(axios.request).toHaveBeenCalledWith({


### PR DESCRIPTION
Updated core SDK to decouple it from the axios version it uses. Dependents are now free to use whatever version of axios (or none if another request module is desired).

The old `Authorization` interface had two methods, `authenticate` and `authenticateGeneric`. The `authenticate` method was tied to axios so it was removed. The `authenticateGeneric` method was then renamed to `authenticate` and its return type was changed slightly to make it easier to use. (It now returns headers which can be folded into the user's request rather than simply the token.)

The code that used the `authenticate` method was updated accordingly.

Unit tests were also updated as well. A couple of unit tests were moved and a few unrelated new unit tests were added to more fully cover `endpoint-client.ts` as well.

While this is _technically_ a breaking change, the only dependent that will break because of it is the CLI so I opted not to confuse users by including that to the release notes.

I have tested this locally with both the CLI and the SmartApp SDK.