### PR TITLE
fix: workaround axios bug

### DIFF
--- a/.changeset/shiny-swans-flash.md
+++ b/.changeset/shiny-swans-flash.md
@@ -1,0 +1,5 @@
+---
+"@smartthings/core-sdk": patch
+---
+
+work around bug in axios 0.28.1

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ a work in progress. Changes may still be made that are not backwardly compatible
 npm install @smartthings/core-sdk
 ```
 
+:warning: Note that if you use axios in your project, you must use version 0.28.1 or later.
+
 ## Importing
 
 `NodeJS`:

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
 			"license": "Apache-2.0",
 			"dependencies": {
 				"async-mutex": "^0.4.0",
-				"axios": "^0.28",
+				"axios": "^0.28.1",
 				"http-signature": "^1.3.6",
 				"lodash.isdate": "^4.0.1",
 				"lodash.isstring": "^4.0.1",
@@ -3114,9 +3114,9 @@
 			}
 		},
 		"node_modules/axios": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-0.28.0.tgz",
-			"integrity": "sha512-Tu7NYoGY4Yoc7I+Npf9HhUMtEEpV7ZiLH9yndTCoNhcpBH0kwcvFbzYN9/u5QKI5A6uefjsNNWaz5olJVYS62Q==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-0.28.1.tgz",
+			"integrity": "sha512-iUcGA5a7p0mVb4Gm/sy+FSECNkPFT4y7wt6OM/CDpO/OnNCvSs3PoMG8ibrC9jRoGYU0gUK5pXVC4NPXq6lHRQ==",
 			"dependencies": {
 				"follow-redirects": "^1.15.0",
 				"form-data": "^4.0.0",
@@ -12031,9 +12031,9 @@
 			"dev": true
 		},
 		"axios": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-0.28.0.tgz",
-			"integrity": "sha512-Tu7NYoGY4Yoc7I+Npf9HhUMtEEpV7ZiLH9yndTCoNhcpBH0kwcvFbzYN9/u5QKI5A6uefjsNNWaz5olJVYS62Q==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-0.28.1.tgz",
+			"integrity": "sha512-iUcGA5a7p0mVb4Gm/sy+FSECNkPFT4y7wt6OM/CDpO/OnNCvSs3PoMG8ibrC9jRoGYU0gUK5pXVC4NPXq6lHRQ==",
 			"requires": {
 				"follow-redirects": "^1.15.0",
 				"form-data": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
 	],
 	"dependencies": {
 		"async-mutex": "^0.4.0",
-		"axios": "^0.28",
+		"axios": "^0.28.1",
 		"http-signature": "^1.3.6",
 		"lodash.isdate": "^4.0.1",
 		"lodash.isstring": "^4.0.1",

--- a/src/endpoint-client.ts
+++ b/src/endpoint-client.ts
@@ -73,7 +73,9 @@ export interface EndpointClientRequestOptions <T> {
  * Meant to be used before logging the request
  */
 function scrubConfig(config: AxiosRequestConfig): string {
-	const message = JSON.stringify(config)
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	const { paramsSerializer: _unused, ...cleanerConfig } = config
+	const message = JSON.stringify(cleanerConfig)
 	const bearerRegex = /"(Bearer [0-9a-f]{8})[0-9a-f-]{28}"/i
 
 	if (bearerRegex.test(message)) {
@@ -180,7 +182,9 @@ export class EndpointClient {
 			headers: options?.headerOverrides ? { ...headers, ...options.headerOverrides } : headers,
 			params,
 			data,
-			paramsSerializer: params => qs.stringify(params, { indices: false }),
+			paramsSerializer: {
+				serialize: params => qs.stringify(params, { indices: false }),
+			},
 		}
 
 		const authHeaders = await this.config.authenticator.authenticate()

--- a/test/unit/endpoint-client.test.ts
+++ b/test/unit/endpoint-client.test.ts
@@ -1,5 +1,5 @@
 import { Mutex } from 'async-mutex'
-import axios, { AxiosError, AxiosRequestConfig, AxiosResponse } from 'axios'
+import axios, { AxiosError, AxiosRequestConfig, AxiosResponse, ParamsSerializerOptions } from 'axios'
 import qs from 'qs'
 
 import { AuthData, Authenticator, BearerTokenAuthenticator, NoOpAuthenticator, RefreshData,
@@ -150,17 +150,17 @@ describe('EndpointClient',  () => {
 				},
 				data: undefined,
 				params: undefined,
-				paramsSerializer: expect.any(Function),
+				paramsSerializer: expect.objectContaining({ serialize: expect.any(Function) }),
 			})
 			expect(response.status).toBe('ok')
 
 			const stringifyMock = (qs.stringify as jest.Mock<string, [unknown]>)
 				.mockReturnValue('stringified parameters')
 			// eslint-disable-next-line @typescript-eslint/no-explicit-any
-			const paramsSerializer = mockRequest.mock.calls[0][0].paramsSerializer as (params: any) => string
+			const paramsSerializer = mockRequest.mock.calls[0][0].paramsSerializer as ParamsSerializerOptions
 
 			expect(paramsSerializer).toBeDefined()
-			expect(paramsSerializer({ param: 'value' })).toBe('stringified parameters')
+			expect(paramsSerializer.serialize?.({ param: 'value' })).toBe('stringified parameters')
 
 			expect(stringifyMock).toHaveBeenCalledTimes(1)
 			expect(stringifyMock).toHaveBeenCalledWith({ param: 'value' }, { indices: false })
@@ -184,7 +184,7 @@ describe('EndpointClient',  () => {
 				},
 				data: undefined,
 				params: undefined,
-				paramsSerializer: expect.any(Function),
+				paramsSerializer: expect.objectContaining({ serialize: expect.any(Function) }),
 			})
 			expect(response.status).toBe('ok')
 		})
@@ -203,7 +203,7 @@ describe('EndpointClient',  () => {
 				},
 				data: undefined,
 				params: undefined,
-				paramsSerializer: expect.any(Function),
+				paramsSerializer: expect.objectContaining({ serialize: expect.any(Function) }),
 			})
 			expect(response.status).toBe('ok')
 		})
@@ -226,7 +226,7 @@ describe('EndpointClient',  () => {
 				},
 				data: { name: 'Bob' },
 				params: undefined,
-				paramsSerializer: expect.any(Function),
+				paramsSerializer: expect.objectContaining({ serialize: expect.any(Function) }),
 			})
 			expect(response.status).toBe('ok')
 		})
@@ -244,7 +244,7 @@ describe('EndpointClient',  () => {
 				},
 				data: undefined,
 				params: undefined,
-				paramsSerializer: expect.any(Function),
+				paramsSerializer: expect.objectContaining({ serialize: expect.any(Function) }),
 			})
 			expect(response.status).toBe('ok')
 		})
@@ -267,7 +267,7 @@ describe('EndpointClient',  () => {
 				},
 				data: undefined,
 				params: undefined,
-				paramsSerializer: expect.any(Function),
+				paramsSerializer: expect.objectContaining({ serialize: expect.any(Function) }),
 			})
 			expect(response.status).toBe('ok')
 
@@ -424,7 +424,7 @@ describe('EndpointClient',  () => {
 				},
 				data: undefined,
 				params: undefined,
-				paramsSerializer: expect.any(Function),
+				paramsSerializer: expect.objectContaining({ serialize: expect.any(Function) }),
 			})
 			expect(response.status).toBe('ok')
 		})
@@ -443,7 +443,7 @@ describe('EndpointClient',  () => {
 				params: {
 					locationId: 'XXX',
 				},
-				paramsSerializer: expect.any(Function),
+				paramsSerializer: expect.objectContaining({ serialize: expect.any(Function) }),
 			})
 			expect(response.status).toBe('ok')
 		})
@@ -460,7 +460,7 @@ describe('EndpointClient',  () => {
 				},
 				data: undefined,
 				params: undefined,
-				paramsSerializer: expect.any(Function),
+				paramsSerializer: expect.objectContaining({ serialize: expect.any(Function) }),
 			})
 			expect(response.status).toBe('ok')
 		})
@@ -477,7 +477,7 @@ describe('EndpointClient',  () => {
 				},
 				data: undefined,
 				params: undefined,
-				paramsSerializer: expect.any(Function),
+				paramsSerializer: expect.objectContaining({ serialize: expect.any(Function) }),
 			})
 			expect(response.status).toBe('ok')
 		})
@@ -497,7 +497,7 @@ describe('EndpointClient',  () => {
 				name: 'Bill',
 			},
 			params: undefined,
-			paramsSerializer: expect.any(Function),
+			paramsSerializer: expect.objectContaining({ serialize: expect.any(Function) }),
 		})
 		expect(response.status).toBe('ok')
 	})
@@ -516,7 +516,7 @@ describe('EndpointClient',  () => {
 				name: 'Bill',
 			},
 			params: undefined,
-			paramsSerializer: expect.any(Function),
+			paramsSerializer: expect.objectContaining({ serialize: expect.any(Function) }),
 		})
 		expect(response.status).toBe('ok')
 	})
@@ -535,7 +535,7 @@ describe('EndpointClient',  () => {
 				name: 'Joe',
 			},
 			params: undefined,
-			paramsSerializer: expect.any(Function),
+			paramsSerializer: expect.objectContaining({ serialize: expect.any(Function) }),
 		})
 		expect(response.status).toBe('ok')
 	})
@@ -552,7 +552,7 @@ describe('EndpointClient',  () => {
 			},
 			data: undefined,
 			params: undefined,
-			paramsSerializer: expect.any(Function),
+			paramsSerializer: expect.objectContaining({ serialize: expect.any(Function) }),
 		})
 		expect(response.status).toBe('ok')
 	})

--- a/test/unit/helpers/utils.ts
+++ b/test/unit/helpers/utils.ts
@@ -4,7 +4,7 @@ export function expectedRequest(config: any): any {
 		data: undefined,
 		params: undefined,
 		...config,
-		paramsSerializer: expect.any(Function),
+		paramsSerializer: expect.objectContaining({ serialize: expect.any(Function) }),
 	}
 }
 
@@ -19,6 +19,6 @@ export function buildRequest(path?: string, params?: any, data?: any, method = '
 		},
 		data: data,
 		params: params,
-		paramsSerializer: expect.any(Function),
+		paramsSerializer: expect.objectContaining({ serialize: expect.any(Function) }),
 	}
 }


### PR DESCRIPTION
While the documentation for axios suggests that using a simple function for `paramsSerializer` should work with 0.28, [it does not](https://github.com/axios/axios/issues/6341). Since npm considers 0.28 and 0.28.1 to be compatible, users or the core SDK who also include axios 0.28.1 are getting errors. This updates the core SDK to 0.28.1. This will break users who are using anything less than 0.28.1 (hence the note in the README).