### PR TITLE
fix: implement workaround for schema invitations endpoint returning 403

### DIFF
--- a/.changeset/good-houses-give.md
+++ b/.changeset/good-houses-give.md
@@ -1,0 +1,5 @@
+---
+"@smartthings/core-sdk": patch
+---
+
+implement workaround for schema invitations endpoint returning 403

--- a/src/endpoint/invites-schemaApp.ts
+++ b/src/endpoint/invites-schemaApp.ts
@@ -41,7 +41,15 @@ export class InvitesSchemaAppEndpoint extends Endpoint {
 	}
 
 	public async list(schemaAppId: string): Promise<SchemaAppInvitation[]> {
-		return this.client.getPagedItems('', { schemaAppId })
+		try {
+			return await this.client.getPagedItems('', { schemaAppId })
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		} catch(error: any) {
+			if (error.response?.status === 403) {
+				return []
+			}
+			throw error
+		}
 	}
 
 	public async revoke(invitationId: string): Promise<void> {

--- a/src/endpoint/schema.ts
+++ b/src/endpoint/schema.ts
@@ -292,12 +292,13 @@ export class SchemaEndpoint extends Endpoint {
 	}
 
 	/**
-	 * Update an ST Schema connector
+	 * Update an ST Schema connector. The connector cannot be changed if the connector's
+	 * `certificationStatus` is `wwst` or `cst`.
 	 *
 	 * @param id the "endpointApp" UUID of the connector, e.g. "viper_799ff3a0-8249-11e9-9bf1-b5c7d651c2c3"
 	 * @param data new definition of the connector
 	 * @param organizationId The organization to associate the connector with. You must be a member
-	 * of the organization. The organization cannot be changed if the connector's `certificationStatus` is `wwst`.
+	 * of the organization.
 	 */
 	public async update(id: string, data: SchemaAppRequest, organizationId?: string): Promise<Status> {
 		const options = organizationId ? { headerOverrides: { 'X-ST-Organization': organizationId } } : undefined

--- a/test/unit/invites-schemaApp.test.ts
+++ b/test/unit/invites-schemaApp.test.ts
@@ -37,6 +37,17 @@ test('list', async () => {
 	expect(getPagedItemsSpy).toHaveBeenCalledWith('', { schemaAppId: 'schema-app-id' })
 })
 
+test('list with 403 error', async () => {
+	getPagedItemsSpy.mockImplementationOnce(() => {
+		throw { response: { status: 403 } }
+	})
+
+	expect(await invitesEndpoint.list('schema-app-id')).toStrictEqual([])
+
+	expect(getPagedItemsSpy).toHaveBeenCalledTimes(1)
+	expect(getPagedItemsSpy).toHaveBeenCalledWith('', { schemaAppId: 'schema-app-id' })
+})
+
 test('revoke', async () => {
 	await expect(invitesEndpoint.revoke('schema-app-id')).resolves.not.toThrow()
 


### PR DESCRIPTION
* implement a workaround for the schema invites endpoint throwing a 403 for schema connectors without an organization id
* some minor comment updates