### PR TITLE
fix: add missing export on AttributeState

### DIFF
--- a/.changeset/forty-monkeys-sneeze.md
+++ b/.changeset/forty-monkeys-sneeze.md
@@ -1,0 +1,5 @@
+---
+"@smartthings/core-sdk": patch
+---
+
+add missing export on AttributeState

--- a/src/endpoint/devices.ts
+++ b/src/endpoint/devices.ts
@@ -774,11 +774,11 @@ export interface DeviceList {
 	_links: Links
 }
 
-interface AttributeState {
+export interface AttributeState {
 	value?: unknown
 	unit?: string
 	data?: { [name: string]: object }
-	timestamp?: string // date-time ("Will always be 0 time-zone offset" whatever that means)
+	timestamp?: string
 }
 
 export interface CapabilityStatus {


### PR DESCRIPTION
Added missing export for `AttributeState` interface.