### PR TITLE
fix: iconImage in an app response is optional

### DIFF
--- a/.changeset/perfect-ravens-guess.md
+++ b/.changeset/perfect-ravens-guess.md
@@ -1,0 +1,5 @@
+---
+"@smartthings/core-sdk": patch
+---
+
+mark iconImage field as optional in app response

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,9 +25,11 @@ We're always looking for more opinions on discussions in the issue tracker. It's
 - Non-trivial changes are often best discussed in an issue first, to prevent you from doing unnecessary work.
 - For ambitious tasks, you should try to get your work in front of the community for feedback as soon as possible. Open a pull request as soon as you have done the minimum needed to demonstrate your idea. At this early stage, don't worry about making things perfect, or 100% complete. Describe what you still need to do and submit a [draft pull request](https://github.blog/2019-02-14-introducing-draft-pull-requests/). This lets reviewers know not to nit-pick small details or point out improvements you already know you need to make.
 - Don't include unrelated changes
+- Pull requests should include only a single commit. You can use `git rebase -i main` to combine multiple commits into a single one if necessary.
 - New features should be accompanied with tests and documentation
 - Commit messages
-  - Use a clear and descriptive title for the pull request and commits
+  - Use a clear and descriptive title for the pull request and commits.
+  - Commit messages must be formatted properly using [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/).
   - We use changesets to automatically version and publish releases, and generate release notes.
     Please include one with your pull request by following the instructions to
 	[add a changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).

--- a/src/endpoint/apps.ts
+++ b/src/endpoint/apps.ts
@@ -186,7 +186,7 @@ export interface PagedApp extends AppBase {
 	/**
 	 * A default icon image for the app.
 	 */
-	iconImage: Required<IconImage>
+	iconImage?: Required<IconImage>
 
 	/**
 	 * A typed model which provides information around ownership of a specific domain.


### PR DESCRIPTION
## Changes

* marked `iconImage` field as optional in response from API
* minor updates to `CONTRIBUTING.md` document to make things more clear

## Notes

The `iconImage` field is an object which contains a single `url` key which means there are three possible ways this can be defined:

1. The `iconImage` field is omitted entirely.
2. It is included but `url` is not. (`"iconImage": {}`)
3. It is included with a `url` populated. (`"iconImage": { "url": "<my-url>" }`)

When submitting data to the API, all three are accepted and work as expected.

When retrieving data, option 2 is sensibly never returned, normalizing to option 1 if option 2 was submitted via creation.

So, the type used for creation and updating was left as `iconImage?: IconImage` which allows for all three cases, but the type for the return value was changed to `iconImage?: Required<IconImage>` which allows for options 1 and 3. (The previous value of `iconImage: Required<IconImage>` allowed only for option 3.)