### PR TITLE
fix: use baseURL for OAuth token endpoint rather tnan separate authURL

### DIFF
--- a/.changeset/legal-apes-matter.md
+++ b/.changeset/legal-apes-matter.md
@@ -1,0 +1,5 @@
+---
+"@smartthings/core-sdk": patch
+---
+
+fix: use baseURL for OAuth token endpoint rather tnan separate authURL

--- a/src/authenticator.ts
+++ b/src/authenticator.ts
@@ -102,7 +102,7 @@ export class RefreshTokenAuthenticator implements Authenticator {
 		}
 
 		const axiosConfig: AxiosRequestConfig = {
-			url: clientConfig.urlProvider?.authURL,
+			url: `${clientConfig.urlProvider?.baseURL}/oauth/token`,
 			method: 'POST',
 			headers,
 			data: `grant_type=refresh_token&client_id=${refreshData.clientId}&refresh_token=${refreshData.refreshToken}`,

--- a/src/endpoint-client.ts
+++ b/src/endpoint-client.ts
@@ -21,13 +21,11 @@ export type HttpClientMethod =
 
 export interface SmartThingsURLProvider {
 	baseURL: string
-	authURL?: string
 	keyApiURL?: string
 }
 
 export const globalSmartThingsURLProvider: Required<SmartThingsURLProvider> = {
 	baseURL: 'https://api.smartthings.com',
-	authURL: 'https://auth-global.api.smartthings.com/oauth/token',
 	keyApiURL: 'https://key.smartthings.com',
 }
 

--- a/src/st-client.ts
+++ b/src/st-client.ts
@@ -103,7 +103,7 @@ export class SmartThingsOAuthClient {
 
 	constructor(private clientId: string, private clientSecret: string,
 			private redirectUri: string, urlProvider?: SmartThingsURLProvider) {
-		this.authURL = urlProvider?.authURL || globalSmartThingsURLProvider.authURL
+		this.authURL = `${urlProvider?.baseURL || globalSmartThingsURLProvider.baseURL}/oauth/token`
 	}
 
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/test/unit/authenticator.test.ts
+++ b/test/unit/authenticator.test.ts
@@ -66,7 +66,7 @@ describe('authenticators', () => {
 
 			expect(axios.request).toHaveBeenCalledTimes(1)
 			expect(axios.request).toHaveBeenCalledWith({
-				'url': 'https://auth-global.api.smartthings.com/oauth/token',
+				'url': 'https://api.smartthings.com/oauth/token',
 				'method': 'POST',
 				'headers': {
 					'Content-Type': 'application/x-www-form-urlencoded',
@@ -128,7 +128,7 @@ describe('authenticators', () => {
 
 				expect(axios.request).toHaveBeenCalledTimes(1)
 				expect(axios.request).toHaveBeenCalledWith({
-					'url': 'https://auth-global.api.smartthings.com/oauth/token',
+					'url': 'https://api.smartthings.com/oauth/token',
 					'method': 'POST',
 					'headers': {
 						'Content-Type': 'application/x-www-form-urlencoded',
@@ -146,7 +146,7 @@ describe('authenticators', () => {
 
 				expect(axios.request).toHaveBeenCalledTimes(1)
 				expect(axios.request).toHaveBeenCalledWith({
-					'url': 'https://auth-global.api.smartthings.com/oauth/token',
+					'url': 'https://api.smartthings.com/oauth/token',
 					'method': 'POST',
 					'headers': {
 						'Content-Type': 'application/x-www-form-urlencoded',

--- a/test/unit/signature.test.ts
+++ b/test/unit/signature.test.ts
@@ -44,7 +44,6 @@ describe('ST Padlock', () => {
 		const resolver = new HttpKeyResolver({
 			urlProvider: {
 				baseURL: 'https://api.smartthings.com',
-				authURL: 'https://auth-global.api.smartthings.com/oauth/token',
 				keyApiURL: 'https://keys.smartthingsdev.com',
 			},
 		})


### PR DESCRIPTION
The searate authURL is no longer used in documentation and not guaranteed to be supported in the future. This change only impacts TypeScipt integrations to pre-production SmartThings environments (which require URL overriding). Integrations to the production environment using default URLs are not affected.

<!-- Describe your pull request. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] I have read the **[CONTRIBUTING](/CONTRIBUTING.md)** document
- [ ] My code follows the code style of this project (`npm run lint` produces no warnings/errors)
- [ ] Any required documentation has been added
- [ ] I have added tests to cover my changes
