### PR TITLE
feat: add enable and disable methods to RulesEndpoint

### DIFF
--- a/.changeset/witty-rules-toggle.md
+++ b/.changeset/witty-rules-toggle.md
@@ -1,0 +1,5 @@
+---
+'@smartthings/core-sdk': minor
+---
+
+Add enable and disable methods to RulesEndpoint

--- a/src/endpoint/rules.ts
+++ b/src/endpoint/rules.ts
@@ -414,4 +414,24 @@ export class RulesEndpoint extends Endpoint {
 	public async execute(id: string, locationId?: string): Promise<RuleExecutionResponse> {
 		return this.client.post(`execute/${id}`, undefined, { locationId: this.locationId(locationId) })
 	}
+
+	/**
+	 * Enable a rule
+	 * @param id UUID of the rule
+	 * @param locationId UUID of the location, If the client is configured with a location ID this parameter
+	 * can be omitted
+	 */
+	public async enable(id: string, locationId?: string): Promise<void> {
+		await this.client.put(`${id}/status/enable`, undefined, { locationId: this.locationId(locationId) })
+	}
+
+	/**
+	 * Disable a rule
+	 * @param id UUID of the rule
+	 * @param locationId UUID of the location, If the client is configured with a location ID this parameter
+	 * can be omitted
+	 */
+	public async disable(id: string, locationId?: string): Promise<void> {
+		await this.client.put(`${id}/status/disable`, undefined, { locationId: this.locationId(locationId) })
+	}
 }

--- a/test/unit/rules.test.ts
+++ b/test/unit/rules.test.ts
@@ -86,4 +86,26 @@ describe('RulesEndpoint', () => {
 		expect(postSpy).toHaveBeenCalledTimes(1)
 		expect(postSpy).toHaveBeenCalledWith('execute/id-of-rule-to-execute', undefined, { locationId: 'final-location-id' })
 	})
+
+	test('enable', async () => {
+		putSpy.mockResolvedValueOnce(undefined)
+
+		await rulesEndpoint.enable('id-of-rule-to-enable', 'input-location-id')
+
+		expect(putSpy).toHaveBeenCalledTimes(1)
+		expect(putSpy).toHaveBeenCalledWith('id-of-rule-to-enable/status/enable', undefined, { locationId: 'final-location-id' })
+		expect(locationIdMock).toHaveBeenCalledTimes(1)
+		expect(locationIdMock).toHaveBeenCalledWith('input-location-id')
+	})
+
+	test('disable', async () => {
+		putSpy.mockResolvedValueOnce(undefined)
+
+		await rulesEndpoint.disable('id-of-rule-to-disable', 'input-location-id')
+
+		expect(putSpy).toHaveBeenCalledTimes(1)
+		expect(putSpy).toHaveBeenCalledWith('id-of-rule-to-disable/status/disable', undefined, { locationId: 'final-location-id' })
+		expect(locationIdMock).toHaveBeenCalledTimes(1)
+		expect(locationIdMock).toHaveBeenCalledWith('input-location-id')
+	})
 })


### PR DESCRIPTION
Adds `enable()` and `disable()` to `RulesEndpoint`, covering the rule status endpoints:

- `PUT /rules/{ruleId}/status/enable?locationId={locationId}`
- `PUT /rules/{ruleId}/status/disable?locationId={locationId}`

These are in the SmartThings public Postman workspace ("Update Rule status (enable/disable)") but missing from the SDK. SmartThingsCommunity/smartthings-cli#500 asks for enable/disable in the CLI and notes it needs SDK support first — I'd like to follow up with a CLI PR once this lands.

Both methods return `Promise<void>` since the API responds with 204 and no body.

Tested against the live API with a `w:rules:*` scoped token: both calls return 204 and a subsequent `GET` shows `status` toggling between `Enabled`/`Disabled`. Unit tests added, lint and full suite pass, changeset included.